### PR TITLE
Read RSSI from a connected BLE device

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ For location permissions on iOS see more at: [https://developer.apple.com/docume
 | state                       |  :white_check_mark:  |  :white_check_mark:  | Stream of state changes for the Bluetooth Device. |
 | mtu                         |  :white_check_mark:  |  :white_check_mark:  | Stream of mtu size changes. |
 | requestMtu                  |  :white_check_mark:  |                      | Request to change the MTU for the device. |
+| readRssi                    |  :white_check_mark:  |  :white_check_mark:  | Read RSSI from a connected device. |
 
 ### BluetoothCharacteristic API
 |                             |       Android        |         iOS          |             Description            |

--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -659,6 +659,24 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
         break;
       }
 
+      case "readRssi":
+      {
+        String remoteId = (String)call.arguments;
+        BluetoothGatt gatt;
+        try {
+          gatt = locateGatt(remoteId);
+          if(gatt.readRemoteRssi()) {
+            result.success(null);
+          } else {
+            result.error("readRssi", "gatt.readRemoteRssi returned false", null);
+          }
+        } catch(Exception e) {
+          result.error("readRssi", e.getMessage(), e);
+        }
+
+        break;
+      }
+
       default:
       {
         result.notImplemented();
@@ -996,6 +1014,12 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
     @Override
     public void onReadRemoteRssi(BluetoothGatt gatt, int rssi, int status) {
       log(LogLevel.DEBUG, "[onReadRemoteRssi] rssi: " + rssi + " status: " + status);
+      if(status == BluetoothGatt.GATT_SUCCESS) {
+        Protos.ReadRssiResult.Builder p = Protos.ReadRssiResult.newBuilder();
+        p.setRemoteId(gatt.getDevice().getAddress());
+        p.setRssi(rssi);
+        invokeMethodUIThread("ReadRssiResult", p.build().toByteArray());
+      }
     }
 
     @Override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -267,9 +267,22 @@ class DeviceScreen extends StatelessWidget {
               stream: device.state,
               initialData: BluetoothDeviceState.connecting,
               builder: (c, snapshot) => ListTile(
-                leading: (snapshot.data == BluetoothDeviceState.connected)
-                    ? Icon(Icons.bluetooth_connected)
-                    : Icon(Icons.bluetooth_disabled),
+                leading: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(snapshot.data == BluetoothDeviceState.connected
+                        ? Icons.bluetooth_connected
+                        : Icons.bluetooth_disabled),
+                    snapshot.data == BluetoothDeviceState.connected
+                        ? StreamBuilder<int>(
+                        stream: rssiStream(),
+                        builder: (context, snapshot) {
+                          return Text(snapshot.hasData ? '${snapshot.data}dBm' : '',
+                              style: Theme.of(context).textTheme.caption);
+                        })
+                        : Text('', style: Theme.of(context).textTheme.caption),
+                  ],
+                ),
                 title: Text(
                     'Device is ${snapshot.data.toString().split('.')[1]}.'),
                 subtitle: Text('${device.id}'),
@@ -323,5 +336,12 @@ class DeviceScreen extends StatelessWidget {
         ),
       ),
     );
+  }
+  
+  Stream<int> rssiStream() async* {
+    for (;;) {
+      yield await device.readRssi();
+      await Future.delayed(Duration(seconds: 1));
+    }
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -274,9 +274,9 @@ class DeviceScreen extends StatelessWidget {
                 leading: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Icon(snapshot.data == BluetoothDeviceState.connected
-                        ? const Icons.bluetooth_connected
-                        : const Icons.bluetooth_disabled),
+                    snapshot.data == BluetoothDeviceState.connected
+                        ? const Icon(Icons.bluetooth_connected)
+                        : const Icon(Icons.bluetooth_disabled),
                     snapshot.data == BluetoothDeviceState.connected
                         ? StreamBuilder<int>(
                         stream: rssiStream(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -343,9 +343,15 @@ class DeviceScreen extends StatelessWidget {
   }
   
   Stream<int> rssiStream() async* {
-    for (;;) {
+    var isConnected = true;
+    final subscription = device.state.listen((state) {
+      isConnected = state == BluetoothDeviceState.connected;
+    });
+    while (isConnected) {
       yield await device.readRssi();
       await Future.delayed(Duration(seconds: 1));
     }
+    subscription.cancel();
+    // Device disconnected, stopping RSSI stream
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -82,7 +82,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.1.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -109,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -183,7 +190,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -259,6 +259,15 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     }
   } else if([@"requestMtu" isEqualToString:call.method]) {
     result([FlutterError errorWithCode:@"requestMtu" message:@"iOS does not allow mtu requests to the peripheral" details:NULL]);
+  } else if([@"readRssi" isEqualToString:call.method]) {
+    NSString *remoteId = [call arguments];
+    @try {
+      CBPeripheral *peripheral = [self findPeripheral:remoteId];
+      [peripheral readRSSI];
+      result(nil);
+    } @catch(FlutterError *e) {
+      result(e);
+    }
   } else {
     result(FlutterMethodNotImplemented);
   }
@@ -553,6 +562,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
   [result setRequest:request];
   [result setSuccess:(error == nil)];
   [_channel invokeMethod:@"WriteDescriptorResponse" arguments:[self toFlutterData:result]];
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral didReadRSSI:(NSNumber *)rssi error:(NSError *)error {
+  ProtosReadRssiResult *result = [[ProtosReadRssiResult alloc] init];
+  [result setRemoteId:[peripheral.identifier UUIDString]];
+  [result setRssi:[rssi intValue]];
+  [_channel invokeMethod:@"ReadRssiResult" arguments:[self toFlutterData:result]];
 }
 
 //

--- a/ios/gen/Flutterblueplus.pbobjc.h
+++ b/ios/gen/Flutterblueplus.pbobjc.h
@@ -777,6 +777,21 @@ GPB_FINAL @interface ProtosMtuSizeResponse : GPBMessage
 
 @end
 
+#pragma mark - ProtosReadRssiResult
+
+typedef GPB_ENUM(ProtosReadRssiResult_FieldNumber) {
+  ProtosReadRssiResult_FieldNumber_RemoteId = 1,
+  ProtosReadRssiResult_FieldNumber_Rssi = 2,
+};
+
+GPB_FINAL @interface ProtosReadRssiResult : GPBMessage
+
+@property(nonatomic, readwrite, copy, null_resettable) NSString *remoteId;
+
+@property(nonatomic, readwrite) int32_t rssi;
+
+@end
+
 NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END

--- a/ios/gen/Flutterblueplus.pbobjc.m
+++ b/ios/gen/Flutterblueplus.pbobjc.m
@@ -2213,6 +2213,62 @@ typedef struct ProtosMtuSizeResponse__storage_ {
 
 @end
 
+#pragma mark - ProtosReadRssiResult
+
+@implementation ProtosReadRssiResult
+
+@dynamic remoteId;
+@dynamic rssi;
+
+typedef struct ProtosReadRssiResult__storage_ {
+  uint32_t _has_storage_[1];
+  int32_t rssi;
+  NSString *remoteId;
+} ProtosReadRssiResult__storage_;
+
+// This method is threadsafe because it is initially called
+// in +initialize for each subclass.
++ (GPBDescriptor *)descriptor {
+  static GPBDescriptor *descriptor = nil;
+  if (!descriptor) {
+    static GPBMessageFieldDescription fields[] = {
+      {
+        .name = "remoteId",
+        .dataTypeSpecific.clazz = Nil,
+        .number = ProtosReadRssiResult_FieldNumber_RemoteId,
+        .hasIndex = 0,
+        .offset = (uint32_t)offsetof(ProtosReadRssiResult__storage_, remoteId),
+        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldClearHasIvarOnZero),
+        .dataType = GPBDataTypeString,
+      },
+      {
+        .name = "rssi",
+        .dataTypeSpecific.clazz = Nil,
+        .number = ProtosReadRssiResult_FieldNumber_Rssi,
+        .hasIndex = 1,
+        .offset = (uint32_t)offsetof(ProtosReadRssiResult__storage_, rssi),
+        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldClearHasIvarOnZero),
+        .dataType = GPBDataTypeInt32,
+      },
+    };
+    GPBDescriptor *localDescriptor =
+        [GPBDescriptor allocDescriptorForClass:[ProtosReadRssiResult class]
+                                     rootClass:[ProtosFlutterblueplusRoot class]
+                                          file:ProtosFlutterblueplusRoot_FileDescriptor()
+                                        fields:fields
+                                    fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
+                                   storageSize:sizeof(ProtosReadRssiResult__storage_)
+                                         flags:(GPBDescriptorInitializationFlags)(GPBDescriptorInitializationFlag_UsesClassRefs | GPBDescriptorInitializationFlag_Proto3OptionalKnown)];
+    #if defined(DEBUG) && DEBUG
+      NSAssert(descriptor == nil, @"Startup recursed!");
+    #endif  // DEBUG
+    descriptor = localDescriptor;
+  }
+  return descriptor;
+}
+
+@end
+
 
 #pragma clang diagnostic pop
 

--- a/lib/gen/flutterblueplus.pb.dart
+++ b/lib/gen/flutterblueplus.pb.dart
@@ -2186,3 +2186,64 @@ class MtuSizeResponse extends $pb.GeneratedMessage {
   void clearMtu() => clearField(2);
 }
 
+class ReadRssiResult extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReadRssiResult', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'remoteId')
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'rssi', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false
+  ;
+
+  ReadRssiResult._() : super();
+  factory ReadRssiResult({
+    $core.String? remoteId,
+    $core.int? rssi,
+  }) {
+    final _result = create();
+    if (remoteId != null) {
+      _result.remoteId = remoteId;
+    }
+    if (rssi != null) {
+      _result.rssi = rssi;
+    }
+    return _result;
+  }
+  factory ReadRssiResult.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReadRssiResult.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ReadRssiResult clone() => ReadRssiResult()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ReadRssiResult copyWith(void Function(ReadRssiResult) updates) => super.copyWith((message) => updates(message as ReadRssiResult)) as ReadRssiResult; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static ReadRssiResult create() => ReadRssiResult._();
+  ReadRssiResult createEmptyInstance() => create();
+  static $pb.PbList<ReadRssiResult> createRepeated() => $pb.PbList<ReadRssiResult>();
+  @$core.pragma('dart2js:noInline')
+  static ReadRssiResult getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReadRssiResult>(create);
+  static ReadRssiResult? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get remoteId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set remoteId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRemoteId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRemoteId() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get rssi => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set rssi($core.int v) { $_setSignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasRssi() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearRssi() => clearField(2);
+}
+

--- a/lib/gen/flutterblueplus.pbjson.dart
+++ b/lib/gen/flutterblueplus.pbjson.dart
@@ -415,3 +415,14 @@ const MtuSizeResponse$json = const {
 
 /// Descriptor for `MtuSizeResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List mtuSizeResponseDescriptor = $convert.base64Decode('Cg9NdHVTaXplUmVzcG9uc2USGwoJcmVtb3RlX2lkGAEgASgJUghyZW1vdGVJZBIQCgNtdHUYAiABKA1SA210dQ==');
+@$core.Deprecated('Use readRssiResultDescriptor instead')
+const ReadRssiResult$json = const {
+  '1': 'ReadRssiResult',
+  '2': const [
+    const {'1': 'remote_id', '3': 1, '4': 1, '5': 9, '10': 'remoteId'},
+    const {'1': 'rssi', '3': 2, '4': 1, '5': 5, '10': 'rssi'},
+  ],
+};
+
+/// Descriptor for `ReadRssiResult`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List readRssiResultDescriptor = $convert.base64Decode('Cg5SZWFkUnNzaVJlc3VsdBIbCglyZW1vdGVfaWQYASABKAlSCHJlbW90ZUlkEhIKBHJzc2kYAiABKAVSBHJzc2k=');

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -152,6 +152,24 @@ class BluetoothDevice {
   Future<bool> get canSendWriteWithoutResponse =>
       Future.error(UnimplementedError());
 
+  /// Read the RSSI for a connected remote device
+  Future<int> readRssi() async {
+    final remoteId = id.toString();
+    await FlutterBluePlus.instance._channel
+        .invokeMethod('readRssi', remoteId);
+
+    return FlutterBluePlus.instance._methodStream
+        .where((m) => m.method == "ReadRssiResult")
+        .map((m) => m.arguments)
+        .map((buffer) => protos.ReadRssiResult.fromBuffer(buffer))
+        .where((p) =>
+    (p.remoteId == remoteId))
+        .first
+        .then((c) {
+      return (c.rssi);
+    });
+  }
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/protos/flutterblueplus.proto
+++ b/protos/flutterblueplus.proto
@@ -212,3 +212,8 @@ message MtuSizeResponse {
   string remote_id = 1;
   uint32 mtu = 2;
 }
+
+message ReadRssiResult {
+  string remote_id = 1;
+  int32 rssi = 2;
+}

--- a/protos/regenerate.md
+++ b/protos/regenerate.md
@@ -1,0 +1,14 @@
+// Copyright 2017, Paul DeMarco.\
+// All rights reserved. Use of this source code is governed by a\
+// BSD-style license that can be found in the LICENSE file.
+
+# Generate protobuf files in Dart
+1. If upgrading, delete all proto files from /home/.pub-cache/bin
+1. Clone the latest dart-protoc-plugin from https://github.com/dart-lang/protobuf
+1. Run `dart pub install` inside protobuf/protoc_plugin
+1. Run `dart pub global activate protoc_plugin` to get .dart files into /home/.pub-cache/bin/
+1. Get the latest linux protoc compiler from https://github.com/google/protobuf/releases/ (protoc-X.X.X-linux-x86_64.zip)
+1. Copy /bin/protoc into /home/.pub-cache/bin/
+1. Run the following commands from this project's protos folder
+```protoc --dart_out=../lib/gen ./flutterblueplus.proto```
+```protoc --objc_out=../ios/gen ./flutterblueplus.proto```


### PR DESCRIPTION
This change adds functionality to read RSSI from a connected device. All required logic to iOS and Android native code is implemented and protos have been updated and regenerated for the required data structures
The example app was also updated to periodically show the RSSI of a connected device.
Furthermore, the regenerate.md file from flutter_blue was copied and flutter_blue_plus related changes were done to help anyone when doing future changes to protos.