### PR TITLE
Remove connect to BLE device after BLE device has disconnected

### DIFF
--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -123,10 +123,8 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
                                    message:@"Peripheral not found"
                                    details:nil];
       }
-      if( [peripheral state] == CBPeripheralStateDisconnected){
-        [_centralManager connectPeripheral:peripheral options:nil];
-      }
       // TODO: Implement Connect options (#36)
+      [_centralManager connectPeripheral:peripheral options:nil];
       result(nil);
     } @catch(FlutterError *e) {
       result(e);
@@ -395,19 +393,8 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
 - (void)centralManager:(CBCentralManager *)central didDisconnectPeripheral:(CBPeripheral *)peripheral error:(NSError *)error {
   NSLog(@"didDisconnectPeripheral");
-  // if user disconnect manually, error code should be 0
-  if( [error code] != 0 ){
-    // unexpected disconnection -> try reconnect
-    @try {
-      NSLog(@"didDisconnectPeripheral:trying reconnect");
-      [central connectPeripheral:peripheral options:nil];
-    } @catch(FlutterError *e) {
-    }
-  }else{
-    NSLog(@"didDisconnectPeripheral:user disconnected");
-    // Unregister self as delegate for peripheral, not working #42
-    peripheral.delegate = nil;
-  }
+  // Unregister self as delegate for peripheral, not working #42
+  peripheral.delegate = nil;
 
   // Send connection state
   [_channel invokeMethod:@"DeviceState" arguments:[self toFlutterData:[self toDeviceStateProto:peripheral state:peripheral.state]]];


### PR DESCRIPTION
This change is undoing commit c7bbdf0c8dbf808c5081a8db8ed00c4eb0bce4ef / Ios : try reconnect on unexpected disconnection (fixed by EB-Plum)

That change introduces a behaviour, where the plugin code tries to connect immediately with a BLE device after it detects a disconnect from that device (except for the case where the disconnect was issued by the app). For cases where a disconnect issued by a BLE device is part of the intended work-flow, an automatic reconnect may not be desired. Furthermore, when powering-off a connected BLE device, it will go to the "connecting" state rather than being "disconnected" as expected.

It should be up to the app to decide, if it reconnects or not after a disconnect callback is received. This could be easy to achieve by setting a flag when the app disconnects the device and checking that flag in the disconnect callback.