### PR TITLE
add bluetoothDevice constructor from id

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -82,7 +82,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.1.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -109,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -183,7 +190,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -14,6 +14,11 @@ class BluetoothDevice {
         name = p.name,
         type = BluetoothDeviceType.values[p.type.value];
 
+  BluetoothDevice.fromId(String id)
+      : id = DeviceIdentifier(id),
+        name = "Unknown name",
+        type = BluetoothDeviceType.unknown;
+
   final BehaviorSubject<bool> _isDiscoveringServices =
       BehaviorSubject.seeded(false);
   Stream<bool> get isDiscoveringServices => _isDiscoveringServices.stream;


### PR DESCRIPTION
My use case needed to take advantage of the fact that I already know the mac address of the device I want to talk to. This constructor method enable the ability to request to android to connect to a specific device as soon as it becomes available on the bluetooth "network".