### PR TITLE
Android - Check for the disconnected state right after the disconnect

### DIFF
--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -347,11 +347,11 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
       {
         String deviceId = (String)call.arguments;
         BluetoothDevice device = mBluetoothAdapter.getRemoteDevice(deviceId);
-        int state = mBluetoothManager.getConnectionState(device, BluetoothProfile.GATT);
         BluetoothDeviceCache cache = mDevices.remove(deviceId);
         if(cache != null) {
           BluetoothGatt gattServer = cache.gatt;
           gattServer.disconnect();
+          int state = mBluetoothManager.getConnectionState(device, BluetoothProfile.GATT);
           if(state == BluetoothProfile.STATE_DISCONNECTED) {
             gattServer.close();
           }


### PR DESCRIPTION
The previous approach wasn't disconnecting properly and the device could be still connected under the hood as the `cancel()` was not called.