### PR TITLE
android bluetooth close instead of disconnect

### DIFF
--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -349,12 +349,7 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
         BluetoothDevice device = mBluetoothAdapter.getRemoteDevice(deviceId);
         BluetoothDeviceCache cache = mDevices.remove(deviceId);
         if(cache != null) {
-          BluetoothGatt gattServer = cache.gatt;
-          gattServer.disconnect();
-          int state = mBluetoothManager.getConnectionState(device, BluetoothProfile.GATT);
-          if(state == BluetoothProfile.STATE_DISCONNECTED) {
-            gattServer.close();
-          }
+          cache.gatt.close();
         }
         result.success(null);
         break;


### PR DESCRIPTION
I know that recently I made a [similar PR](https://github.com/boskokg/flutter_blue_plus/pull/24), however, it's still not ideal and there is a space for a race condition and chance of skipping the `.close()` call. After doing more research, I've realized that calling the `.disconnect()` isn't needed at all as `.close()` does it all. The `.disconnect()` is useful only when we want to call `.connect()` on the same `BluetoothGatt` later, which we don't use at all and we want to disconnect completely.

https://stackoverflow.com/a/23657148/5647161