### PR TITLE
Scan Filter by Mac Address

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,25 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.boskokg.flutter_blue_plus">
+  package="com.boskokg.flutter_blue_plus">
 
     <!-- New Bluetooth permissions in Android 12
            https://developer.android.com/about/versions/12/features/bluetooth-permissions
       -->
     <!-- Include "neverForLocation" only if you can strongly assert that
            your app never derives physical location from Bluetooth scan results. -->
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_SCAN"
-        android:usesPermissionFlags="neverForLocation"
-        tools:targetApi="s" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <!-- Request legacy Bluetooth permissions on older devices. -->
-    <uses-permission
-        android:name="android.permission.BLUETOOTH"
-        android:maxSdkVersion="30" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_ADMIN"
-        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,16 +1,25 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.boskokg.flutter_blue_plus">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.boskokg.flutter_blue_plus">
 
     <!-- New Bluetooth permissions in Android 12
            https://developer.android.com/about/versions/12/features/bluetooth-permissions
       -->
     <!-- Include "neverForLocation" only if you can strongly assert that
            your app never derives physical location from Bluetooth scan results. -->
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <!-- Request legacy Bluetooth permissions on older devices. -->
-    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 </manifest>

--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -878,7 +878,7 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
 
     for (int i = 0; i < count; i++) {
       ScanFilter f;
-      if (macCount == count) {
+      if (macCount > 0) {
         String macAddress = proto.getMacAddresses(i);
         f = new ScanFilter.Builder().setDeviceAddress(macAddress).build();
       } else {

--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -868,7 +868,13 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
       ScanFilter f = new ScanFilter.Builder().setServiceUuid(ParcelUuid.fromString(uuid)).build();
       filters.add(f);
     }
-    ScanSettings settings = new ScanSettings.Builder().setScanMode(scanMode).build();
+    ScanSettings settings = new ScanSettings.Builder()
+          .setScanMode(scanMode)
+          .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
+          .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
+          .setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT)
+          .setReportDelay(0L)
+          .build();
     scanner.startScan(filters, settings, getScanCallback21());
   }
 

--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
@@ -861,21 +862,33 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
     BluetoothLeScanner scanner = mBluetoothAdapter.getBluetoothLeScanner();
     if(scanner == null) throw new IllegalStateException("getBluetoothLeScanner() is null. Is the Adapter on?");
     int scanMode = proto.getAndroidScanMode();
-    int count = proto.getServiceUuidsCount();
-    List<ScanFilter> filters = new ArrayList<>(count);
-    for(int i = 0; i < count; i++) {
-      String uuid = proto.getServiceUuids(i);
-      ScanFilter f = new ScanFilter.Builder().setServiceUuid(ParcelUuid.fromString(uuid)).build();
+    List<ScanFilter> filters = fetchFilters(proto);
+    ScanSettings settings = new ScanSettings.Builder().setScanMode(scanMode).build();
+    scanner.startScan(filters, settings, getScanCallback21());
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private List<ScanFilter> fetchFilters(Protos.ScanSettings proto) {
+    List<ScanFilter> filters;
+
+    int macCount = proto.getMacAddressesCount();
+    int serviceCount = proto.getServiceUuidsCount();
+    int count = macCount > 0 ? macCount : serviceCount;
+    filters = new ArrayList<>(count);
+
+    for (int i = 0; i < count; i++) {
+      ScanFilter f;
+      if (macCount == count) {
+        String macAddress = proto.getMacAddresses(i);
+        f = new ScanFilter.Builder().setDeviceAddress(macAddress).build();
+      } else {
+        String uuid = proto.getServiceUuids(i);
+        f = new ScanFilter.Builder().setServiceUuid(ParcelUuid.fromString(uuid)).build();
+      }
       filters.add(f);
     }
-    ScanSettings settings = new ScanSettings.Builder()
-          .setScanMode(scanMode)
-          .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
-          .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
-          .setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT)
-          .setReportDelay(0L)
-          .build();
-    scanner.startScan(filters, settings, getScanCallback21());
+
+    return filters;
   }
 
   @TargetApi(21)

--- a/lib/gen/flutterblueplus.pb.dart
+++ b/lib/gen/flutterblueplus.pb.dart
@@ -213,6 +213,7 @@ class ScanSettings extends $pb.GeneratedMessage {
     ..a<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'androidScanMode', $pb.PbFieldType.O3)
     ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceUuids')
     ..aOB(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'allowDuplicates')
+    ..pPS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'macAddresses')
     ..hasRequiredFields = false
   ;
 
@@ -221,6 +222,7 @@ class ScanSettings extends $pb.GeneratedMessage {
     $core.int? androidScanMode,
     $core.Iterable<$core.String>? serviceUuids,
     $core.bool? allowDuplicates,
+    $core.Iterable<$core.String>? macAddresses,
   }) {
     final _result = create();
     if (androidScanMode != null) {
@@ -231,6 +233,9 @@ class ScanSettings extends $pb.GeneratedMessage {
     }
     if (allowDuplicates != null) {
       _result.allowDuplicates = allowDuplicates;
+    }
+    if (macAddresses != null) {
+      _result.macAddresses.addAll(macAddresses);
     }
     return _result;
   }
@@ -275,6 +280,9 @@ class ScanSettings extends $pb.GeneratedMessage {
   $core.bool hasAllowDuplicates() => $_has(2);
   @$pb.TagNumber(3)
   void clearAllowDuplicates() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.List<$core.String> get macAddresses => $_getList(3);
 }
 
 class ScanResult extends $pb.GeneratedMessage {

--- a/lib/gen/flutterblueplus.pbjson.dart
+++ b/lib/gen/flutterblueplus.pbjson.dart
@@ -86,11 +86,12 @@ const ScanSettings$json = const {
     const {'1': 'android_scan_mode', '3': 1, '4': 1, '5': 5, '10': 'androidScanMode'},
     const {'1': 'service_uuids', '3': 2, '4': 3, '5': 9, '10': 'serviceUuids'},
     const {'1': 'allow_duplicates', '3': 3, '4': 1, '5': 8, '10': 'allowDuplicates'},
+    const {'1': 'mac_addresses', '3': 4, '4': 3, '5': 9, '10': 'macAddresses'},
   ],
 };
 
 /// Descriptor for `ScanSettings`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List scanSettingsDescriptor = $convert.base64Decode('CgxTY2FuU2V0dGluZ3MSKgoRYW5kcm9pZF9zY2FuX21vZGUYASABKAVSD2FuZHJvaWRTY2FuTW9kZRIjCg1zZXJ2aWNlX3V1aWRzGAIgAygJUgxzZXJ2aWNlVXVpZHMSKQoQYWxsb3dfZHVwbGljYXRlcxgDIAEoCFIPYWxsb3dEdXBsaWNhdGVz');
+final $typed_data.Uint8List scanSettingsDescriptor = $convert.base64Decode('CgxTY2FuU2V0dGluZ3MSKgoRYW5kcm9pZF9zY2FuX21vZGUYASABKAVSD2FuZHJvaWRTY2FuTW9kZRIjCg1zZXJ2aWNlX3V1aWRzGAIgAygJUgxzZXJ2aWNlVXVpZHMSKQoQYWxsb3dfZHVwbGljYXRlcxgDIAEoCFIPYWxsb3dEdXBsaWNhdGVzEiMKDW1hY19hZGRyZXNzZXMYBCADKAlSDG1hY0FkZHJlc3Nlcw==');
 @$core.Deprecated('Use scanResultDescriptor instead')
 const ScanResult$json = const {
   '1': 'ScanResult',

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -5,11 +5,14 @@
 part of flutter_blue_plus;
 
 class FlutterBluePlus {
-  final MethodChannel _channel = const MethodChannel('flutter_blue_plus/methods');
-  final EventChannel _stateChannel = const EventChannel('flutter_blue_plus/state');
-  final StreamController<MethodCall> _methodStreamController = StreamController.broadcast(); // ignore: close_sinks
-  Stream<MethodCall> get _methodStream =>
-      _methodStreamController.stream; // Used internally to dispatch methods from platform.
+  final MethodChannel _channel =
+      const MethodChannel('flutter_blue_plus/methods');
+  final EventChannel _stateChannel =
+      const EventChannel('flutter_blue_plus/state');
+  final StreamController<MethodCall> _methodStreamController =
+      StreamController.broadcast(); // ignore: close_sinks
+  Stream<MethodCall> get _methodStream => _methodStreamController
+      .stream; // Used internally to dispatch methods from platform.
 
   /// Singleton boilerplate
   FlutterBluePlus._() {
@@ -28,7 +31,8 @@ class FlutterBluePlus {
   LogLevel get logLevel => _logLevel;
 
   /// Checks whether the device supports Bluetooth
-  Future<bool> get isAvailable => _channel.invokeMethod('isAvailable').then<bool>((d) => d);
+  Future<bool> get isAvailable =>
+      _channel.invokeMethod('isAvailable').then<bool>((d) => d);
 
   /// Checks if Bluetooth functionality is turned on
   Future<bool> get isOn => _channel.invokeMethod('isOn').then<bool>((d) => d);
@@ -58,7 +62,8 @@ class FlutterBluePlus {
   final BehaviorSubject<bool> _isScanning = BehaviorSubject.seeded(false);
   Stream<bool> get isScanning => _isScanning.stream;
 
-  final BehaviorSubject<List<ScanResult>> _scanResults = BehaviorSubject.seeded([]);
+  final BehaviorSubject<List<ScanResult>> _scanResults =
+      BehaviorSubject.seeded([]);
 
   /// Returns a stream that is a list of [ScanResult] results while a scan is in progress.
   ///
@@ -241,7 +246,15 @@ enum LogLevel {
 }
 
 /// State of the bluetooth adapter.
-enum BluetoothState { unknown, unavailable, unauthorized, turningOn, on, turningOff, off }
+enum BluetoothState {
+  unknown,
+  unavailable,
+  unauthorized,
+  turningOn,
+  on,
+  turningOff,
+  off
+}
 
 class ScanMode {
   const ScanMode(this.value);
@@ -263,7 +276,8 @@ class DeviceIdentifier {
   int get hashCode => id.hashCode;
 
   @override
-  bool operator ==(other) => other is DeviceIdentifier && compareAsciiLowerCase(id, other.id) == 0;
+  bool operator ==(other) =>
+      other is DeviceIdentifier && compareAsciiLowerCase(id, other.id) == 0;
 }
 
 class ScanResult {
@@ -278,7 +292,10 @@ class ScanResult {
 
   @override
   bool operator ==(Object other) =>
-      identical(this, other) || other is ScanResult && runtimeType == other.runtimeType && device == other.device;
+      identical(this, other) ||
+      other is ScanResult &&
+          runtimeType == other.runtimeType &&
+          device == other.device;
 
   @override
   int get hashCode => device.hashCode;
@@ -299,7 +316,8 @@ class AdvertisementData {
 
   AdvertisementData.fromProto(protos.AdvertisementData p)
       : localName = p.localName,
-        txPowerLevel = (p.txPowerLevel.hasValue()) ? p.txPowerLevel.value : null,
+        txPowerLevel =
+            (p.txPowerLevel.hasValue()) ? p.txPowerLevel.value : null,
         connectable = p.connectable,
         manufacturerData = p.manufacturerData,
         serviceData = p.serviceData,

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -5,14 +5,11 @@
 part of flutter_blue_plus;
 
 class FlutterBluePlus {
-  final MethodChannel _channel =
-      const MethodChannel('flutter_blue_plus/methods');
-  final EventChannel _stateChannel =
-      const EventChannel('flutter_blue_plus/state');
-  final StreamController<MethodCall> _methodStreamController =
-      StreamController.broadcast(); // ignore: close_sinks
-  Stream<MethodCall> get _methodStream => _methodStreamController
-      .stream; // Used internally to dispatch methods from platform.
+  final MethodChannel _channel = const MethodChannel('flutter_blue_plus/methods');
+  final EventChannel _stateChannel = const EventChannel('flutter_blue_plus/state');
+  final StreamController<MethodCall> _methodStreamController = StreamController.broadcast(); // ignore: close_sinks
+  Stream<MethodCall> get _methodStream =>
+      _methodStreamController.stream; // Used internally to dispatch methods from platform.
 
   /// Singleton boilerplate
   FlutterBluePlus._() {
@@ -31,8 +28,7 @@ class FlutterBluePlus {
   LogLevel get logLevel => _logLevel;
 
   /// Checks whether the device supports Bluetooth
-  Future<bool> get isAvailable =>
-      _channel.invokeMethod('isAvailable').then<bool>((d) => d);
+  Future<bool> get isAvailable => _channel.invokeMethod('isAvailable').then<bool>((d) => d);
 
   /// Checks if Bluetooth functionality is turned on
   Future<bool> get isOn => _channel.invokeMethod('isOn').then<bool>((d) => d);
@@ -62,8 +58,7 @@ class FlutterBluePlus {
   final BehaviorSubject<bool> _isScanning = BehaviorSubject.seeded(false);
   Stream<bool> get isScanning => _isScanning.stream;
 
-  final BehaviorSubject<List<ScanResult>> _scanResults =
-      BehaviorSubject.seeded([]);
+  final BehaviorSubject<List<ScanResult>> _scanResults = BehaviorSubject.seeded([]);
 
   /// Returns a stream that is a list of [ScanResult] results while a scan is in progress.
   ///
@@ -117,12 +112,14 @@ class FlutterBluePlus {
     ScanMode scanMode = ScanMode.lowLatency,
     List<Guid> withServices = const [],
     List<Guid> withDevices = const [],
+    List<String> macAddresses = const [],
     Duration? timeout,
     bool allowDuplicates = false,
   }) async* {
     var settings = protos.ScanSettings.create()
       ..androidScanMode = scanMode.value
       ..allowDuplicates = allowDuplicates
+      ..macAddresses.addAll(macAddresses)
       ..serviceUuids.addAll(withServices.map((g) => g.toString()).toList());
 
     if (_isScanning.value == true) {
@@ -242,15 +239,7 @@ enum LogLevel {
 }
 
 /// State of the bluetooth adapter.
-enum BluetoothState {
-  unknown,
-  unavailable,
-  unauthorized,
-  turningOn,
-  on,
-  turningOff,
-  off
-}
+enum BluetoothState { unknown, unavailable, unauthorized, turningOn, on, turningOff, off }
 
 class ScanMode {
   const ScanMode(this.value);
@@ -272,8 +261,7 @@ class DeviceIdentifier {
   int get hashCode => id.hashCode;
 
   @override
-  bool operator ==(other) =>
-      other is DeviceIdentifier && compareAsciiLowerCase(id, other.id) == 0;
+  bool operator ==(other) => other is DeviceIdentifier && compareAsciiLowerCase(id, other.id) == 0;
 }
 
 class ScanResult {
@@ -288,10 +276,7 @@ class ScanResult {
 
   @override
   bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is ScanResult &&
-          runtimeType == other.runtimeType &&
-          device == other.device;
+      identical(this, other) || other is ScanResult && runtimeType == other.runtimeType && device == other.device;
 
   @override
   int get hashCode => device.hashCode;
@@ -312,8 +297,7 @@ class AdvertisementData {
 
   AdvertisementData.fromProto(protos.AdvertisementData p)
       : localName = p.localName,
-        txPowerLevel =
-            (p.txPowerLevel.hasValue()) ? p.txPowerLevel.value : null,
+        txPowerLevel = (p.txPowerLevel.hasValue()) ? p.txPowerLevel.value : null,
         connectable = p.connectable,
         manufacturerData = p.manufacturerData,
         serviceData = p.serviceData,

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -181,6 +181,7 @@ class FlutterBluePlus {
     ScanMode scanMode = ScanMode.lowLatency,
     List<Guid> withServices = const [],
     List<Guid> withDevices = const [],
+    List<String> macAddresses = const [],
     Duration? timeout,
     bool allowDuplicates = false,
   }) async {
@@ -188,6 +189,7 @@ class FlutterBluePlus {
             scanMode: scanMode,
             withServices: withServices,
             withDevices: withDevices,
+            macAddresses: macAddresses,
             timeout: timeout,
             allowDuplicates: allowDuplicates)
         .drain();

--- a/protos/flutterblueplus.proto
+++ b/protos/flutterblueplus.proto
@@ -42,6 +42,7 @@ message ScanSettings {
   int32 android_scan_mode = 1;
   repeated string service_uuids = 2;
   bool allow_duplicates = 3;
+  repeated string mac_addresses = 4;
 }
 
 message ScanResult {


### PR DESCRIPTION
Added scan with mac addresses support, has of android 8 if the screen is turned off you can only scan with filters, and these filters cannot be empty in some distributions, as I didn't have access to the UUIDs of my Bluetooth devices I decided to create this pull request with support for such a thing.


Links to information related to the pull request.
https://us.community.samsung.com/t5/Galaxy-S21/Issue-with-Bluetooth-on-S21-Ultra/td-p/1706765
https://stackoverflow.com/questions/65199141/delphi-android-scanning-bluetooth-le-devices-does-not-work-while-screen-is-off
https://stackoverflow.com/questions/48077690/ble-scan-is-not-working-when-screen-is-off-on-android-8-1-0
https://medium.com/@martijn.van.welie/making-android-ble-work-part-1-a736dcd53b02
