### PR TITLE
Added scan record rawbytes to advertisementdata

### DIFF
--- a/android/src/main/java/com/boskokg/flutter_blue_plus/ProtoMaker.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/ProtoMaker.java
@@ -91,6 +91,9 @@ public class ProtoMaker {
                     a.addServiceUuids(s.getUuid().toString());
                 }
             }
+            byte[] rawBytes = scanRecord.getBytes();
+            if(rawBytes!=null)
+                a.setRawBytes(ByteString.copyFrom(rawBytes));
         }
         p.setRssi(scanResult.getRssi());
         p.setAdvertisementData(a.build());

--- a/ios/gen/Flutterblueplus.pbobjc.h
+++ b/ios/gen/Flutterblueplus.pbobjc.h
@@ -199,6 +199,7 @@ typedef GPB_ENUM(ProtosAdvertisementData_FieldNumber) {
   ProtosAdvertisementData_FieldNumber_ManufacturerData = 4,
   ProtosAdvertisementData_FieldNumber_ServiceData = 5,
   ProtosAdvertisementData_FieldNumber_ServiceUuidsArray = 6,
+  ProtosAdvertisementData_FieldNumber_RawBytes = 7,
 };
 
 GPB_FINAL @interface ProtosAdvertisementData : GPBMessage
@@ -224,6 +225,8 @@ GPB_FINAL @interface ProtosAdvertisementData : GPBMessage
 @property(nonatomic, readwrite, strong, null_resettable) NSMutableArray<NSString*> *serviceUuidsArray;
 /** The number of items in @c serviceUuidsArray without causing the array to be created. */
 @property(nonatomic, readonly) NSUInteger serviceUuidsArray_Count;
+
+@property(nonatomic, readwrite, copy, null_resettable) NSData *rawBytes;
 
 @end
 

--- a/ios/gen/Flutterblueplus.pbobjc.m
+++ b/ios/gen/Flutterblueplus.pbobjc.m
@@ -219,6 +219,7 @@ BOOL ProtosBluetoothState_State_IsValidValue(int32_t value__) {
 @dynamic manufacturerData, manufacturerData_Count;
 @dynamic serviceData, serviceData_Count;
 @dynamic serviceUuidsArray, serviceUuidsArray_Count;
+@dynamic rawBytes;
 
 typedef struct ProtosAdvertisementData__storage_ {
   uint32_t _has_storage_[1];
@@ -227,6 +228,7 @@ typedef struct ProtosAdvertisementData__storage_ {
   GPBInt32ObjectDictionary *manufacturerData;
   NSMutableDictionary *serviceData;
   NSMutableArray *serviceUuidsArray;
+  NSData *rawBytes;
 } ProtosAdvertisementData__storage_;
 
 // This method is threadsafe because it is initially called
@@ -288,6 +290,15 @@ typedef struct ProtosAdvertisementData__storage_ {
         .offset = (uint32_t)offsetof(ProtosAdvertisementData__storage_, serviceUuidsArray),
         .flags = GPBFieldRepeated,
         .dataType = GPBDataTypeString,
+      },
+      {
+        .name = "rawBytes",
+        .dataTypeSpecific.clazz = Nil,
+        .number = ProtosAdvertisementData_FieldNumber_RawBytes,
+        .hasIndex = 4,
+        .offset = (uint32_t)offsetof(ProtosAdvertisementData__storage_, rawBytes),
+        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldClearHasIvarOnZero),
+        .dataType = GPBDataTypeBytes,
       },
     };
     GPBDescriptor *localDescriptor =

--- a/lib/flutter_blue_plus.dart
+++ b/lib/flutter_blue_plus.dart
@@ -5,6 +5,7 @@
 library flutter_blue_plus;
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:convert/convert.dart';

--- a/lib/gen/flutterblueplus.pb.dart
+++ b/lib/gen/flutterblueplus.pb.dart
@@ -3,7 +3,7 @@
 //  source: flutterblueplus.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 import 'dart:core' as $core;
 
@@ -115,6 +115,7 @@ class AdvertisementData extends $pb.GeneratedMessage {
     ..m<$core.int, $core.List<$core.int>>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'manufacturerData', entryClassName: 'AdvertisementData.ManufacturerDataEntry', keyFieldType: $pb.PbFieldType.O3, valueFieldType: $pb.PbFieldType.OY)
     ..m<$core.String, $core.List<$core.int>>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceData', entryClassName: 'AdvertisementData.ServiceDataEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OY)
     ..pPS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceUuids')
+    ..a<$core.List<$core.int>>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'rawBytes', $pb.PbFieldType.OY)
     ..hasRequiredFields = false
   ;
 
@@ -126,6 +127,7 @@ class AdvertisementData extends $pb.GeneratedMessage {
     $core.Map<$core.int, $core.List<$core.int>>? manufacturerData,
     $core.Map<$core.String, $core.List<$core.int>>? serviceData,
     $core.Iterable<$core.String>? serviceUuids,
+    $core.List<$core.int>? rawBytes,
   }) {
     final _result = create();
     if (localName != null) {
@@ -145,6 +147,9 @@ class AdvertisementData extends $pb.GeneratedMessage {
     }
     if (serviceUuids != null) {
       _result.serviceUuids.addAll(serviceUuids);
+    }
+    if (rawBytes != null) {
+      _result.rawBytes = rawBytes;
     }
     return _result;
   }
@@ -206,6 +211,15 @@ class AdvertisementData extends $pb.GeneratedMessage {
 
   @$pb.TagNumber(6)
   $core.List<$core.String> get serviceUuids => $_getList(5);
+
+  @$pb.TagNumber(7)
+  $core.List<$core.int> get rawBytes => $_getN(6);
+  @$pb.TagNumber(7)
+  set rawBytes($core.List<$core.int> v) { $_setBytes(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasRawBytes() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearRawBytes() => clearField(7);
 }
 
 class ScanSettings extends $pb.GeneratedMessage {

--- a/lib/gen/flutterblueplus.pbenum.dart
+++ b/lib/gen/flutterblueplus.pbenum.dart
@@ -3,7 +3,7 @@
 //  source: flutterblueplus.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
 import 'dart:core' as $core;

--- a/lib/gen/flutterblueplus.pbjson.dart
+++ b/lib/gen/flutterblueplus.pbjson.dart
@@ -3,7 +3,7 @@
 //  source: flutterblueplus.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;
@@ -53,6 +53,7 @@ const AdvertisementData$json = const {
     const {'1': 'manufacturer_data', '3': 4, '4': 3, '5': 11, '6': '.AdvertisementData.ManufacturerDataEntry', '10': 'manufacturerData'},
     const {'1': 'service_data', '3': 5, '4': 3, '5': 11, '6': '.AdvertisementData.ServiceDataEntry', '10': 'serviceData'},
     const {'1': 'service_uuids', '3': 6, '4': 3, '5': 9, '10': 'serviceUuids'},
+    const {'1': 'raw_bytes', '3': 7, '4': 1, '5': 12, '10': 'rawBytes'},
   ],
   '3': const [AdvertisementData_ManufacturerDataEntry$json, AdvertisementData_ServiceDataEntry$json],
 };
@@ -78,7 +79,7 @@ const AdvertisementData_ServiceDataEntry$json = const {
 };
 
 /// Descriptor for `AdvertisementData`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List advertisementDataDescriptor = $convert.base64Decode('ChFBZHZlcnRpc2VtZW50RGF0YRIdCgpsb2NhbF9uYW1lGAEgASgJUglsb2NhbE5hbWUSMQoOdHhfcG93ZXJfbGV2ZWwYAiABKAsyCy5JbnQzMlZhbHVlUgx0eFBvd2VyTGV2ZWwSIAoLY29ubmVjdGFibGUYAyABKAhSC2Nvbm5lY3RhYmxlElUKEW1hbnVmYWN0dXJlcl9kYXRhGAQgAygLMiguQWR2ZXJ0aXNlbWVudERhdGEuTWFudWZhY3R1cmVyRGF0YUVudHJ5UhBtYW51ZmFjdHVyZXJEYXRhEkYKDHNlcnZpY2VfZGF0YRgFIAMoCzIjLkFkdmVydGlzZW1lbnREYXRhLlNlcnZpY2VEYXRhRW50cnlSC3NlcnZpY2VEYXRhEiMKDXNlcnZpY2VfdXVpZHMYBiADKAlSDHNlcnZpY2VVdWlkcxpDChVNYW51ZmFjdHVyZXJEYXRhRW50cnkSEAoDa2V5GAEgASgFUgNrZXkSFAoFdmFsdWUYAiABKAxSBXZhbHVlOgI4ARo+ChBTZXJ2aWNlRGF0YUVudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgMUgV2YWx1ZToCOAE=');
+final $typed_data.Uint8List advertisementDataDescriptor = $convert.base64Decode('ChFBZHZlcnRpc2VtZW50RGF0YRIdCgpsb2NhbF9uYW1lGAEgASgJUglsb2NhbE5hbWUSMQoOdHhfcG93ZXJfbGV2ZWwYAiABKAsyCy5JbnQzMlZhbHVlUgx0eFBvd2VyTGV2ZWwSIAoLY29ubmVjdGFibGUYAyABKAhSC2Nvbm5lY3RhYmxlElUKEW1hbnVmYWN0dXJlcl9kYXRhGAQgAygLMiguQWR2ZXJ0aXNlbWVudERhdGEuTWFudWZhY3R1cmVyRGF0YUVudHJ5UhBtYW51ZmFjdHVyZXJEYXRhEkYKDHNlcnZpY2VfZGF0YRgFIAMoCzIjLkFkdmVydGlzZW1lbnREYXRhLlNlcnZpY2VEYXRhRW50cnlSC3NlcnZpY2VEYXRhEiMKDXNlcnZpY2VfdXVpZHMYBiADKAlSDHNlcnZpY2VVdWlkcxIbCglyYXdfYnl0ZXMYByABKAxSCHJhd0J5dGVzGkMKFU1hbnVmYWN0dXJlckRhdGFFbnRyeRIQCgNrZXkYASABKAVSA2tleRIUCgV2YWx1ZRgCIAEoDFIFdmFsdWU6AjgBGj4KEFNlcnZpY2VEYXRhRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAxSBXZhbHVlOgI4AQ==');
 @$core.Deprecated('Use scanSettingsDescriptor instead')
 const ScanSettings$json = const {
   '1': 'ScanSettings',

--- a/lib/gen/flutterblueplus.pbserver.dart
+++ b/lib/gen/flutterblueplus.pbserver.dart
@@ -3,7 +3,7 @@
 //  source: flutterblueplus.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 export 'flutterblueplus.pb.dart';
 

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -309,6 +309,7 @@ class AdvertisementData {
   final Map<int, List<int>> manufacturerData;
   final Map<String, List<int>> serviceData;
   final List<String> serviceUuids;
+  final Uint8List rawBytes;
 
   AdvertisementData.fromProto(protos.AdvertisementData p)
       : localName = p.localName,
@@ -317,10 +318,11 @@ class AdvertisementData {
         connectable = p.connectable,
         manufacturerData = p.manufacturerData,
         serviceData = p.serviceData,
-        serviceUuids = p.serviceUuids;
+        serviceUuids = p.serviceUuids,
+        rawBytes = Uint8List.fromList(p.rawBytes);
 
   @override
   String toString() {
-    return 'AdvertisementData{localName: $localName, txPowerLevel: $txPowerLevel, connectable: $connectable, manufacturerData: $manufacturerData, serviceData: $serviceData, serviceUuids: $serviceUuids}';
+    return 'AdvertisementData{localName: $localName, txPowerLevel: $txPowerLevel, connectable: $connectable, manufacturerData: $manufacturerData, serviceData: $serviceData, serviceUuids: $serviceUuids, rawBytes: ${hex.encode(rawBytes)}}';
   }
 }

--- a/protos/flutterblueplus.proto
+++ b/protos/flutterblueplus.proto
@@ -36,6 +36,7 @@ message AdvertisementData {
   map<int32, bytes> manufacturer_data = 4; // Map of manufacturers to their data
   map<string, bytes> service_data = 5;  // Map of service UUIDs to their data.
   repeated string service_uuids = 6;
+  bytes raw_bytes = 7;
 }
 
 message ScanSettings {


### PR DESCRIPTION
Patch for https://github.com/boskokg/flutter_blue_plus/issues/81

# ⚠️  This has only been developped for Android. iOS part is missing!

ToString method of AdvertisementData returns the following:

```
AdvertisementData{localName: AST-2, txPowerLevel: null, connectable: true, manufacturerData: {}, serviceData: {}, serviceUuids: [], rawBytes: 02010603503403035190010352b400035352010354a208035552000356280506094153542d320357ea000358e50b0359b521000000000000000000000000}
```

which seems to work.

I haven't intensively tested as I don't even know if that will be merged but as I needed it for one of my projects, here you are!

Cheers