### PR TITLE
Add `FlutterBlue.name` to get the human readable device name

### DIFF
--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -227,6 +227,15 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
         break;
       }
 
+      case "name":
+      {
+        String name = mBluetoothAdapter.getName();
+        if (name == null)
+          name = "";
+        result.success(name);
+        break;
+      }
+
       case "turnOn":
       {
         if (!mBluetoothAdapter.isEnabled()) {

--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -86,6 +86,8 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     } else {
       result(@(NO));
     }
+  } else if([@"name" isEqualToString:call.method]) {
+    result([[UIDevice currentDevice] name]);
   } else if([@"startScan" isEqualToString:call.method]) {
     // Clear any existing scan results
     [self.scannedPeripherals removeAllObjects];

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -34,6 +34,10 @@ class FlutterBluePlus {
   Future<bool> get isAvailable =>
       _channel.invokeMethod('isAvailable').then<bool>((d) => d);
 
+  /// Return the friendly Bluetooth name of the local Bluetooth adapter
+  Future<String> get name =>
+      _channel.invokeMethod('name').then<String>((d) => d);
+
   /// Checks if Bluetooth functionality is turned on
   Future<bool> get isOn => _channel.invokeMethod('isOn').then<bool>((d) => d);
 


### PR DESCRIPTION
Thanks for continuing the development of flutter_blue, it's a really nice package!

This commit implements a new `FlutterBlue.name` property that will
get the friendly bluetooth name of the local bluetooth adapter.

This is the PRhttps://github.com/pauldemarco/flutter_blue/pull/1085 for this project

I tested this with my android application and it seems to be working just fine, I am not sure if the code needs to be smater if permissions for bluetooth are missing though, happy to look further into this.

Please note that I did not test this under ios, Unfortunately I have no device to test it.
The code is inferred from reading the ios docs, but I'm happy to just leave it unimplemented or add a comment if it's hard to test.