### PR TITLE
Fixes #98 (or at least improves)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,3 +2,9 @@ include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
+
+analyzer:
+  exclude:
+    - /**.pbjson.dart
+    - /**.pb.dart
+    - /**.pbenum.dart

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -349,7 +349,7 @@ class DeviceScreen extends StatelessWidget {
     });
     while (isConnected) {
       yield await device.readRssi();
-      await Future.delayed(Duration(seconds: 1));
+      await Future.delayed(const Duration(seconds: 1));
     }
     subscription.cancel();
     // Device disconnected, stopping RSSI stream

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   fixnum:
     dependency: transitive
     description:
@@ -115,7 +115,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -129,7 +129,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   protobuf:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -190,7 +190,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -204,7 +204,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.15.1 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.5.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -143,7 +143,7 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.3"
+    version: "0.27.5"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/src/guid.dart
+++ b/lib/src/guid.dart
@@ -23,7 +23,7 @@ class Guid {
     final bytes = hex.decode(input);
 
     if (bytes.length != 6) {
-      throw FormatException("The format is invalid: " + input);
+      throw FormatException("The format is invalid: $input");
     }
 
     return bytes + List<int>.filled(10, 0);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   convert: ^3.0.1
   protobuf: ^2.0.1
   rxdart: ^0.27.3
+  collection: ^1.15.0
   meta: ^1.3.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,14 +12,14 @@ dependencies:
     sdk: flutter
   convert: ^3.0.1
   protobuf: ^2.0.1
-  rxdart: ^0.27.3
+  rxdart: ^0.27.5
   collection: ^1.15.0
-  meta: ^1.3.0
+  meta: ^1.7.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
Upgrading to linter 2.0.1, excluding generated ProtoBuf files from linting.