### PR TITLE
Prevent deprecation warnings

### DIFF
--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -913,6 +913,7 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
     return scanCallback18;
   }
 
+  @SuppressWarnings("deprecation")
   private void startScan18(Protos.ScanSettings proto) throws IllegalStateException {
     List<String> serviceUuids = proto.getServiceUuidsList();
     UUID[] uuids = new UUID[serviceUuids.size()];
@@ -923,6 +924,7 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
     if(!success) throw new IllegalStateException("getBluetoothLeScanner() is null. Is the Adapter on?");
   }
 
+  @SuppressWarnings("deprecation")
   private void stopScan18() {
     mBluetoothAdapter.stopLeScan(getScanCallback18());
   }


### PR DESCRIPTION
Here are a couple of annotations added to suppress the deprecation warnings for startLeScan/stopLeScan methods used on pre-Lollipop devices (#46).