### PR TITLE
Allow native implementation to handle pairing request

### DIFF
--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -57,10 +57,8 @@ class BluetoothDevice {
   /// Send a pairing request to the device.
   /// Currently only implemented on Android.
   Future<void> pair() async {
-    if (Platform.isAndroid) {
-      return FlutterBluePlus.instance._channel
-          .invokeMethod('pair', id.toString());
-    }
+    return FlutterBluePlus.instance._channel
+        .invokeMethod('pair', id.toString());
   }
 
   /// Cancels connection to the Bluetooth Device


### PR DESCRIPTION
This pull request removes check for an android platform when calling pair.

I am developing [flutter_blue_plus_tizen](https://github.com/JRazek/plugins/tree/flutter_blue_plus/packages/flutter_blue), plugin that uses dart implementation of flutter_blue_plus.

Pairing is in development on Tizen platform, but dart side prohibits calling the method channel.
After this change, it will throw the exception to the user when a plugin is unimplemented on a native side.