### PR TITLE
Add parameter to avoid CBCentralManagerOptionShowPowerAlertKey alerts on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The BluetoothDevice object is then used to directly interact with characteristic
 FlutterBluePlus flutterBlue = FlutterBluePlus.instance;
 ```
 
-## Disabling CBCentralManagerOptionShowPowerAlertKey
+##### Disabling CBCentralManagerOptionShowPowerAlertKey
 If you do not want to show `CBCentralManagerOptionShowPowerAlertKey` alerts, create your instance as:
 ```dart
 FlutterBluePlus flutterBlue = FlutterBluePlus(showIosPowerAlert: false);

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ The BluetoothDevice object is then used to directly interact with characteristic
 FlutterBluePlus flutterBlue = FlutterBluePlus.instance;
 ```
 
+## Disabling CBCentralManagerOptionShowPowerAlertKey
+If you do not want to show `CBCentralManagerOptionShowPowerAlertKey` alerts, create your instance as:
+```dart
+FlutterBluePlus flutterBlue = FlutterBluePlus(showIosPowerAlert: false);
+```
+
 ### Scan for devices
 ```dart
 // Start scanning

--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -279,6 +279,12 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
         break;
       }
 
+      case "setShowIosPowerAlert":
+      {
+        result.success(null);
+        break;
+      }
+
       case "getConnectedDevices":
       {
         ensurePermissionBeforeAction(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? Manifest.permission.BLUETOOTH_CONNECT : null, (granted, permission) -> {

--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -68,6 +68,14 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     result(nil);
     return;
   }
+  if ([@"setShowIosPowerAlert" isEqualToString:call.method]) {
+    NSNumber *showPowerAlert = [call arguments];
+    if (self.centralManager == nil) {
+      self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil options:@{CBCentralManagerOptionShowPowerAlertKey: showPowerAlert}];
+    }
+    result(nil);
+    return;
+  }
   if (self.centralManager == nil) {
     self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
   }

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -21,15 +21,22 @@ class FlutterBluePlus {
   Stream<BluetoothState>? _stateStream;
 
   /// Singleton boilerplate
-  FlutterBluePlus._() {
+  FlutterBluePlus._({bool showIosPowerAlert = true}) {
     _channel.setMethodCallHandler((MethodCall call) async {
       _methodStreamController.add(call);
     });
 
+    _channel.invokeMethod('setShowIosPowerAlert', showIosPowerAlert);
+
     setLogLevel(logLevel);
   }
 
+  /// FlutterBluePlus factory with optional [showIosPowerAlert] parameter
+  factory FlutterBluePlus({bool showIosPowerAlert = true}) =>
+      FlutterBluePlus._(showIosPowerAlert: showIosPowerAlert);
+
   static final FlutterBluePlus _instance = FlutterBluePlus._();
+
   static FlutterBluePlus get instance => _instance;
 
   /// Log level of the instance, default is all messages (debug).

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -36,7 +36,6 @@ class FlutterBluePlus {
       FlutterBluePlus._(showIosPowerAlert: showIosPowerAlert);
 
   static final FlutterBluePlus _instance = FlutterBluePlus._();
-
   static FlutterBluePlus get instance => _instance;
 
   /// Log level of the instance, default is all messages (debug).


### PR DESCRIPTION
This PR adds an optional parameter to set if you want to show or not `CBCentralManagerOptionShowPowerAlertKey` alerts.

These alerts are showed by default when Bluetooth is turned off and `CBCentralManager` is used on iOS native side.

Examples of alert dialogs:
| Bluetooth fully disabled | Bluetooth disabled for new devices |
| --- | --- |
| ![fully](https://user-images.githubusercontent.com/40506852/185131831-44682625-99cb-4283-a0c7-0e80eee97eeb.PNG) | ![new_devices](https://user-images.githubusercontent.com/40506852/185131791-e81d6ab2-24b2-470d-bedb-d4e29c5c0049.PNG) |

### Creating the instance
To disable it, the instance should be created as:
```dart
FlutterBluePlus flutterBlue = FlutterBluePlus(showIosPowerAlert: false);
```

