### PR TITLE
Fixes iOS apps getting stuck in unknown BT state

### DIFF
--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -268,8 +268,16 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
         ensurePermissionBeforeAction(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? Manifest.permission.BLUETOOTH_SCAN : Manifest.permission.ACCESS_FINE_LOCATION, (grantedScan, permissionScan) -> {
           if (grantedScan) {
             ensurePermissionBeforeAction(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? Manifest.permission.BLUETOOTH_CONNECT : null, (grantedConnect, permissionConnect) -> {
-              if (grantedConnect)
-                startScan(call, result);
+              if (grantedConnect) {
+                ensurePermissionBeforeAction(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? Manifest.permission.ACCESS_FINE_LOCATION : null, (grantedLocation, permissionLocation) -> {
+                  if (grantedLocation) {
+                    startScan(call, result);
+                  }
+                  else
+                    result.error(
+                            "no_permissions", String.format("flutter_blue plugin requires %s for scanning", permissionLocation), null);
+                });
+              }
               else
                 result.error(
                         "no_permissions", String.format("flutter_blue plugin requires %s for scanning", permissionConnect), null);

--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -196,6 +196,34 @@ public class FlutterBluePlusPlugin implements FlutterPlugin, MethodCallHandler, 
         break;
       }
 
+      case "state":
+      {
+        Protos.BluetoothState.Builder p = Protos.BluetoothState.newBuilder();
+        try {
+          switch(mBluetoothAdapter.getState()) {
+            case BluetoothAdapter.STATE_OFF:
+              p.setState(Protos.BluetoothState.State.OFF);
+              break;
+            case BluetoothAdapter.STATE_ON:
+              p.setState(Protos.BluetoothState.State.ON);
+              break;
+            case BluetoothAdapter.STATE_TURNING_OFF:
+              p.setState(Protos.BluetoothState.State.TURNING_OFF);
+              break;
+            case BluetoothAdapter.STATE_TURNING_ON:
+              p.setState(Protos.BluetoothState.State.TURNING_ON);
+              break;
+            default:
+              p.setState(Protos.BluetoothState.State.UNKNOWN);
+              break;
+          }
+        } catch (SecurityException e) {
+          p.setState(Protos.BluetoothState.State.UNAUTHORIZED);
+        }
+        result.success(p.build().toByteArray());
+        break;
+      }
+
       case "isAvailable":
       {
         result.success(mBluetoothAdapter != null);

--- a/ios/Classes/FlutterBluePlusPlugin.h
+++ b/ios/Classes/FlutterBluePlusPlugin.h
@@ -12,4 +12,5 @@
 
 @interface FlutterBluePlusStreamHandler : NSObject<FlutterStreamHandler>
 @property FlutterEventSink sink;
+@property FlutterStandardTypedData *cachedBluetoothState;
 @end

--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -91,8 +91,6 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
   } else if([@"name" isEqualToString:call.method]) {
     result([[UIDevice currentDevice] name]);
   } else if([@"startScan" isEqualToString:call.method]) {
-    // Clear any existing scan results
-    [self.scannedPeripherals removeAllObjects];
     // TODO: Request Permission?
     FlutterStandardTypedData *data = [call arguments];
     ProtosScanSettings *request = [[ProtosScanSettings alloc] initWithData:[data data] error:nil];

--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -73,8 +73,9 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     FlutterStandardTypedData *data = [self toFlutterData:[self toBluetoothStateProto:self->_centralManager.state]];
     self.stateStreamHandler.cachedBluetoothState = data;
   }
-  if ([@"ensureCentralManagerCreated" isEqualToString:call.method]) {
-    result(nil); // created above
+  if ([@"state" isEqualToString:call.method]) {
+    FlutterStandardTypedData *data = [self toFlutterData:[self toBluetoothStateProto:self->_centralManager.state]];
+    result(data);
   } else if([@"isAvailable" isEqualToString:call.method]) {
     if(self.centralManager.state != CBManagerStateUnsupported && self.centralManager.state != CBManagerStateUnknown) {
       result(@(YES));

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -117,8 +117,8 @@ class BluetoothCharacteristic {
     var result = await FlutterBluePlus.instance._channel
         .invokeMethod('writeCharacteristic', request.writeToBuffer());
 
-    if (type == CharacteristicWriteType.withoutResponse) {
-      return result;
+    if (result is bool && result) {
+      return;
     }
 
     return FlutterBluePlus.instance._methodStream

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -77,10 +77,7 @@ class BluetoothCharacteristic {
     FlutterBluePlus.instance._log(LogLevel.info,
         'remoteId: ${deviceId.toString()} characteristicUuid: ${uuid.toString()} serviceUuid: ${serviceUuid.toString()}');
 
-    await FlutterBluePlus.instance._channel
-        .invokeMethod('readCharacteristic', request.writeToBuffer());
-
-    return FlutterBluePlus.instance._methodStream
+    var response = FlutterBluePlus.instance._methodStream
         .where((m) => m.method == "ReadCharacteristicResponse")
         .map((m) => m.arguments)
         .map((buffer) => protos.ReadCharacteristicResponse.fromBuffer(buffer))
@@ -94,6 +91,11 @@ class BluetoothCharacteristic {
       _value.add(d);
       return d;
     });
+
+    await FlutterBluePlus.instance._channel
+        .invokeMethod('readCharacteristic', request.writeToBuffer());
+
+    return response;
   }
 
   /// Writes the value of a characteristic.
@@ -114,14 +116,7 @@ class BluetoothCharacteristic {
           protos.WriteCharacteristicRequest_WriteType.valueOf(type.index)!
       ..value = value;
 
-    var result = await FlutterBluePlus.instance._channel
-        .invokeMethod('writeCharacteristic', request.writeToBuffer());
-
-    if (result is bool && result) {
-      return;
-    }
-
-    return FlutterBluePlus.instance._methodStream
+    var response = FlutterBluePlus.instance._methodStream
         .where((m) => m.method == "WriteCharacteristicResponse")
         .map((m) => m.arguments)
         .map((buffer) => protos.WriteCharacteristicResponse.fromBuffer(buffer))
@@ -135,6 +130,15 @@ class BluetoothCharacteristic {
             ? throw Exception('Failed to write the characteristic')
             : null)
         .then((_) => null);
+
+    var result = await FlutterBluePlus.instance._channel
+        .invokeMethod('writeCharacteristic', request.writeToBuffer());
+
+    if (result is bool && result) {
+      return;
+    }
+
+    return response;
   }
 
   /// Sets notifications or indications for the value of a specified characteristic
@@ -145,10 +149,7 @@ class BluetoothCharacteristic {
       ..characteristicUuid = uuid.toString()
       ..enable = notify;
 
-    await FlutterBluePlus.instance._channel
-        .invokeMethod('setNotification', request.writeToBuffer());
-
-    return FlutterBluePlus.instance._methodStream
+    var response = FlutterBluePlus.instance._methodStream
         .where((m) => m.method == "SetNotificationResponse")
         .map((m) => m.arguments)
         .map((buffer) => protos.SetNotificationResponse.fromBuffer(buffer))
@@ -162,6 +163,11 @@ class BluetoothCharacteristic {
       _updateDescriptors(c.descriptors);
       return (c.isNotifying == notify);
     });
+
+    await FlutterBluePlus.instance._channel
+        .invokeMethod('setNotification', request.writeToBuffer());
+
+    return response;
   }
 
   @override

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -88,9 +88,10 @@ class FlutterBluePlus {
 
   /// Gets the current state of the Bluetooth module
   Stream<BluetoothState> get state async* {
-    if (Platform.isIOS) {
-      await _channel.invokeMethod('ensureCentralManagerCreated');
-    }
+    yield await _channel
+        .invokeMethod('state')
+        .then((buffer) => protos.BluetoothState.fromBuffer(buffer))
+        .then((s) => BluetoothState.values[s.state.value]);
 
     _stateStream ??= _stateChannel
         .receiveBroadcastStream()

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -88,10 +88,9 @@ class FlutterBluePlus {
 
   /// Gets the current state of the Bluetooth module
   Stream<BluetoothState> get state async* {
-    yield await _channel
-        .invokeMethod('state')
-        .then((buffer) => protos.BluetoothState.fromBuffer(buffer))
-        .then((s) => BluetoothState.values[s.state.value]);
+    if (Platform.isIOS) {
+      await _channel.invokeMethod('ensureCentralManagerCreated');
+    }
 
     _stateStream ??= _stateChannel
         .receiveBroadcastStream()


### PR DESCRIPTION
Fixed an issue where iOS apps got stuck in the unknown Bluetooth state #66.
The cause of this problem was that after creating an CBCentralManager object, for a short while the state is unknown which is checked and reported by the plugin. Then two things happen in parallel:

- the plugin starts listening to the state stream,
- iOS calls centralManagerDidUpdateState with the real BT state.

If the centralManagerDidUpdateState call is faster, plugin doesn't get the first state update and is stuck in the unknown state.
Modified the code so that centralManagerDidUpdateState calls are cached before a stream event sink is attached.
I didn't see this problem on Android, but in theory it was also possible that state updates were skipped, so I modified the Android part to match changes for iOS.