### PR TITLE
Opt out of neverForLocation on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.4.0
 **Breaking Change**
-* Opt-out of the `neverForLocation` permission flag for the `BLUETOOTH_SCAN` permission on Android.
+* Android: Opt-out of the `neverForLocation` permission flag for the `BLUETOOTH_SCAN` permission.
 
   If `neverForLocation` is desired,
   opt back into the old behavior by adding an explicit entry to your Android Manifest:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.4.0
+**Breaking Change**
+* Opt-out of the `neverForLocation` permission flag for the `BLUETOOTH_SCAN` permission on Android.
+
+  If `neverForLocation` is desired,
+  opt back into the old behavior by adding an explicit entry to your Android Manifest:
+  ```
+  <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+    android:usesPermissionFlags="neverForLocation" />
+  ```
+
 ## 1.3.1
 * Reverted: Ios: fixed manufacturer data parsing #104 (thanks to sqcsabbey)
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,9 +4,7 @@
     <!-- New Bluetooth permissions in Android 12
            https://developer.android.com/about/versions/12/features/bluetooth-permissions
       -->
-    <!-- Include "neverForLocation" only if you can strongly assert that
-           your app never derives physical location from Bluetooth scan results. -->
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <!-- Request legacy Bluetooth permissions on older devices. -->

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_blue_plus
 description: Flutter plugin for connecting and communicationg with Bluetooth Low Energy devices, on Android and iOS
-version: 1.3.1
+version: 1.4.0
 homepage: https://github.com/boskokg/flutter_blue_plus
 
 environment:


### PR DESCRIPTION
This PR opts out of the `neverForLocation` permission flag on Android.

In general having to opt-in is better than having to explicitly opt-out.

Fixes: #135 Fixes: #120 