### PR TITLE
[Dependencies] Remove unnecessary dependencies: convert, collection, meta

### DIFF
--- a/lib/flutter_blue_plus.dart
+++ b/lib/flutter_blue_plus.dart
@@ -7,8 +7,6 @@ library flutter_blue_plus;
 import 'dart:async';
 import 'dart:io';
 
-import 'package:collection/collection.dart';
-import 'package:convert/convert.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:rxdart/rxdart.dart';
@@ -20,4 +18,5 @@ part 'src/bluetooth_descriptor.dart';
 part 'src/bluetooth_device.dart';
 part 'src/bluetooth_service.dart';
 part 'src/flutter_blue_plus.dart';
+part 'src/utils.dart';
 part 'src/guid.dart';

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -172,7 +172,6 @@ class BluetoothCharacteristic {
 
 enum CharacteristicWriteType { withResponse, withoutResponse }
 
-@immutable
 class CharacteristicProperties {
   final bool broadcast;
   final bool read;

--- a/lib/src/guid.dart
+++ b/lib/src/guid.dart
@@ -20,7 +20,7 @@ class Guid {
 
   static List<int> _fromMacString(String input) {
     input = _removeNonHexCharacters(input);
-    final bytes = hex.decode(input);
+    final bytes = hexDecode(input);
 
     if (bytes.length != 6) {
       throw FormatException("The format is invalid: $input");
@@ -31,7 +31,7 @@ class Guid {
 
   static List<int> _fromString(String input) {
     input = _removeNonHexCharacters(input);
-    final bytes = hex.decode(input);
+    final bytes = hexDecode(input);
 
     if (bytes.length != 16) {
       throw const FormatException("The format is invalid");
@@ -51,27 +51,32 @@ class Guid {
   }
 
   static int _calcHashCode(List<int> bytes) {
-    const equality = ListEquality<int>();
-    return equality.hash(bytes);
+    const int prime1 = 9007199254740881;
+    const int prime2 = 8388880508472777;
+    int hash = 0;
+    for (int value in bytes) {
+      hash = (hash * prime1 + value) % prime2;
+    }
+    return hash;
   }
 
   @override
   String toString() {
-    String one = hex.encode(_bytes.sublist(0, 4));
-    String two = hex.encode(_bytes.sublist(4, 6));
-    String three = hex.encode(_bytes.sublist(6, 8));
-    String four = hex.encode(_bytes.sublist(8, 10));
-    String five = hex.encode(_bytes.sublist(10, 16));
+    String one = hexEncode(_bytes.sublist(0, 4));
+    String two = hexEncode(_bytes.sublist(4, 6));
+    String three = hexEncode(_bytes.sublist(6, 8));
+    String four = hexEncode(_bytes.sublist(8, 10));
+    String five = hexEncode(_bytes.sublist(10, 16));
     return "$one-$two-$three-$four-$five";
   }
 
   String toMac() {
-    String one = hex.encode(_bytes.sublist(0, 1));
-    String two = hex.encode(_bytes.sublist(1, 2));
-    String three = hex.encode(_bytes.sublist(2, 3));
-    String four = hex.encode(_bytes.sublist(3, 4));
-    String five = hex.encode(_bytes.sublist(4, 5));
-    String six = hex.encode(_bytes.sublist(5, 6));
+    String one = hexEncode(_bytes.sublist(0, 1));
+    String two = hexEncode(_bytes.sublist(1, 2));
+    String three = hexEncode(_bytes.sublist(2, 3));
+    String four = hexEncode(_bytes.sublist(3, 4));
+    String five = hexEncode(_bytes.sublist(4, 5));
+    String six = hexEncode(_bytes.sublist(5, 6));
     return "$one:$two:$three:$four:$five:$six".toUpperCase();
   }
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,0 +1,43 @@
+
+
+part of flutter_blue_plus;
+
+String hexEncode(List<int> numbers) {
+  return numbers.map((n) => n.toRadixString(16).padLeft(2, '0')).join();
+}
+
+List<int> hexDecode(String hex) {
+  List<int> numbers = [];
+  for (int i = 0; i < hex.length; i += 2) {
+    String hexPart = hex.substring(i, i + 2);
+    int num = int.parse(hexPart, radix: 16);
+    numbers.add(num);
+  }
+  return numbers;
+}
+
+int compareAsciiLowerCase(String a, String b) {
+  const int upperCaseA = 0x41;
+  const int upperCaseZ = 0x5a;
+  const int asciiCaseBit = 0x20;
+  var defaultResult = 0;
+  for (var i = 0; i < a.length; i++) {
+    if (i >= b.length) return 1;
+    var aChar = a.codeUnitAt(i);
+    var bChar = b.codeUnitAt(i);
+    if (aChar == bChar) continue;
+    var aLowerCase = aChar;
+    var bLowerCase = bChar;
+    // Upper case if ASCII letters.
+    if (upperCaseA <= bChar && bChar <= upperCaseZ) {
+      bLowerCase += asciiCaseBit;
+    }
+    if (upperCaseA <= aChar && aChar <= upperCaseZ) {
+      aLowerCase += asciiCaseBit;
+    }
+    if (aLowerCase != bLowerCase) return (aLowerCase - bLowerCase).sign;
+    if (defaultResult == 0) defaultResult = aChar - bChar;
+  }
+  if (b.length > a.length) return -1;
+  return defaultResult.sign;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  convert: ^3.0.1
   protobuf: ^2.0.1
   rxdart: ^0.27.5
-  collection: ^1.15.0
-  meta: ^1.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Related Issue: https://github.com/boskokg/flutter_blue_plus/issues/236

Remove:
- convert
- collection
- meta

With this simple change, flutter_blue_plus will only have 3 dependencies:
- flutter
- rxdart
- protobuf

There are big advantages to having few dependencies. Namely, you avoid:
- a new version of a dependency causing bugs
- incompatibility between versions
- explosion of child dependencies
- unnecessary library complexity 

I understand these dependencies are some of the safest to include, but they are are incredibly simple to remove.



