### PR TITLE
[Dependencies] Remove rxdart dependency

### DIFF
--- a/lib/flutter_blue_plus.dart
+++ b/lib/flutter_blue_plus.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:rxdart/rxdart.dart';
 
 import 'gen/flutterblueplus.pb.dart' as protos;
 

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -5,12 +5,14 @@
 part of flutter_blue_plus;
 
 class BluetoothCharacteristic {
+
   final Guid uuid;
   final DeviceIdentifier deviceId;
   final Guid serviceUuid;
   final Guid? secondaryServiceUuid;
   final CharacteristicProperties properties;
   final List<BluetoothDescriptor> descriptors;
+
   bool get isNotifying {
     try {
       var cccd =
@@ -22,12 +24,13 @@ class BluetoothCharacteristic {
   }
 
   final BehaviorSubject<List<int>> _value;
-  Stream<List<int>> get value => Rx.merge([
+
+  Stream<List<int>> get value => mergeStreams([
         _value.stream,
         onValueChangedStream,
       ]);
 
-  List<int> get lastValue => _value.value;
+  List<int> get lastValue => _value.latestValue;
 
   BluetoothCharacteristic.fromProto(protos.BluetoothCharacteristic p)
       : uuid = Guid(p.uuid),
@@ -39,7 +42,7 @@ class BluetoothCharacteristic {
         descriptors =
             p.descriptors.map((d) => BluetoothDescriptor.fromProto(d)).toList(),
         properties = CharacteristicProperties.fromProto(p.properties),
-        _value = BehaviorSubject.seeded(p.value);
+        _value = BehaviorSubject(p.value);
 
   Stream<BluetoothCharacteristic> get _onCharacteristicChangedStream =>
       FlutterBluePlus.instance._methodStream

--- a/lib/src/bluetooth_descriptor.dart
+++ b/lib/src/bluetooth_descriptor.dart
@@ -15,14 +15,14 @@ class BluetoothDescriptor {
   final BehaviorSubject<List<int>> _value;
   Stream<List<int>> get value => _value.stream;
 
-  List<int> get lastValue => _value.value;
+  List<int> get lastValue => _value.latestValue;
 
   BluetoothDescriptor.fromProto(protos.BluetoothDescriptor p)
       : uuid = Guid(p.uuid),
         deviceId = DeviceIdentifier(p.remoteId),
         serviceUuid = Guid(p.serviceUuid),
         characteristicUuid = Guid(p.characteristicUuid),
-        _value = BehaviorSubject.seeded(p.value);
+        _value = BehaviorSubject(p.value);
 
   /// Retrieves the value of a specified descriptor
   Future<List<int>> read() async {

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -23,8 +23,8 @@ class BluetoothDevice {
         name = name ?? "Unknown name",
         type = type ?? BluetoothDeviceType.unknown;
 
-  final BehaviorSubject<bool> _isDiscoveringServices =
-      BehaviorSubject.seeded(false);
+  final BehaviorSubject<bool> _isDiscoveringServices = BehaviorSubject(false);
+  
   Stream<bool> get isDiscoveringServices => _isDiscoveringServices.stream;
 
   /// Establishes a connection to the Bluetooth Device.
@@ -75,8 +75,7 @@ class BluetoothDevice {
   Future disconnect() => FlutterBluePlus.instance._channel
       .invokeMethod('disconnect', id.toString());
 
-  final BehaviorSubject<List<BluetoothService>> _services =
-      BehaviorSubject.seeded([]);
+  final BehaviorSubject<List<BluetoothService>> _services = BehaviorSubject([]);
 
   /// Discovers services offered by the remote device as well as their characteristics and descriptors
   Future<List<BluetoothService>> discoverServices() async {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -41,3 +41,152 @@ int compareAsciiLowerCase(String a, String b) {
   if (b.length > a.length) return -1;
   return defaultResult.sign;
 }
+
+
+class BehaviorSubject<T> {
+
+  T latestValue;
+
+  final StreamController<T> _controller = StreamController<T>.broadcast();
+
+  BehaviorSubject(this.latestValue);
+
+  Stream<T> get stream => _controller.stream;
+
+  T get value => latestValue;
+
+  void add(T newValue) {
+    latestValue = newValue;
+    _controller.add(newValue);
+  }
+
+  void listen(Function(T) onData, {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+    _controller.stream.listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    onData(latestValue);
+  }
+
+  Future<void> close() {
+    return _controller.close();
+  }
+}
+
+class OnDoneTransformer<T> extends StreamTransformerBase<T, T> {
+  final Function onDone;
+
+  OnDoneTransformer({required this.onDone});
+
+  @override
+  Stream<T> bind(Stream<T> stream) {
+    StreamController<T>? controller;
+    StreamSubscription<T>? subscription;
+
+    controller = StreamController<T>(
+      onListen: () {
+        subscription = stream.listen(
+          controller?.add,
+          onError: controller?.addError,
+          onDone: () {
+            onDone();
+            controller?.close();
+          },
+        );
+      },
+      onPause: ([Future<dynamic>? resumeSignal]) {
+        subscription?.pause(resumeSignal);
+      },
+      onResume: () {
+        subscription?.resume();
+      },
+      onCancel: () {
+        return subscription?.cancel();
+      },
+      sync: true,
+    );
+
+    return controller.stream;
+  }
+}
+
+extension StreamDoOnDone<T> on Stream<T> {
+  Stream<T> doOnDone(void Function() onDone) {
+    return transform(OnDoneTransformer(onDone: onDone));
+  }
+}
+
+class OnCancelTransformer<T> extends StreamTransformerBase<T, T> {
+  final Function onCancel;
+
+  OnCancelTransformer({required this.onCancel});
+
+  @override
+  Stream<T> bind(Stream<T> stream) {
+    StreamController<T>? controller;
+    StreamSubscription<T>? subscription;
+
+    controller = StreamController<T>(
+      onListen: () {
+        subscription = stream.listen(
+          controller?.add,
+          onError: controller?.addError,
+          onDone: controller?.close,
+        );
+      },
+      onPause: ([Future<dynamic>? resumeSignal]) {
+        subscription?.pause(resumeSignal);
+      },
+      onResume: () {
+        subscription?.resume();
+      },
+      onCancel: () {
+        onCancel();
+        return subscription?.cancel();
+      },
+      sync: true,
+    );
+
+    return controller.stream;
+  }
+}
+
+extension StreamDoOnCancel<T> on Stream<T> {
+  Stream<T> doOnCancel(void Function() onCancel) {
+    return transform(OnCancelTransformer(onCancel: onCancel));
+  }
+}
+
+
+Stream<T> mergeStreams<T>(List<Stream<T>> streams) {
+  StreamController<T> controller = StreamController<T>();
+  List<StreamSubscription<T>> subscriptions = [];
+
+  void handleData(T data) {
+    if (!controller.isClosed) {
+      controller.add(data);
+    }
+  }
+
+  void handleError(Object error, StackTrace stackTrace) {
+    if (!controller.isClosed) {
+      controller.addError(error, stackTrace);
+    }
+  }
+
+  void handleDone() {
+    if (subscriptions.every((s) => s.isPaused)) {
+      controller.close();
+    }
+  }
+
+  void subscribeToStream(Stream<T> stream) {
+    final s = stream.listen(handleData, onError: handleError, onDone: handleDone);
+    subscriptions.add(s);
+  }
+
+  streams.forEach(subscribeToStream);
+
+  controller.onCancel = () async {
+    await Future.wait(subscriptions.map((s) => s.cancel()));
+  };
+
+  return controller.stream;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   flutter:
     sdk: flutter
   protobuf: ^2.0.1
-  rxdart: ^0.27.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Related Issue: https://github.com/boskokg/flutter_blue_plus/issues/236

**Note: this needs more testing! Draft PR.**

 I've started work on removing RxDart. Please just view this commit: https://github.com/boskokg/flutter_blue_plus/pull/240/commits/3cb0a5ec36d7afcb80c017135efe6e9c0483c67f

**Motivation**: RxDart is rather complicated, often updated, and rather overkill. It is only used in a few places for what seem like trivial reasons but it's implementation is hard to understand using multiple layers of abstraction.

There are big advantages to having few dependencies. Namely, you avoid:

- a new version of a dependency causing bugs
- incompatibility between versions
- explosion of child dependencies
- unnecessary library complexity
- binary size

