### PR TITLE
dart api: add isScanningNow variable

### DIFF
--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -70,7 +70,10 @@ class FlutterBluePlus {
   }
 
   final BehaviorSubject<bool> _isScanning = BehaviorSubject(false);
+
   Stream<bool> get isScanning => _isScanning.stream;
+
+  bool get isScanningNow => _isScanning.latestValue;
 
   final BehaviorSubject<List<ScanResult>> _scanResults =
       BehaviorSubject([]);


### PR DESCRIPTION
Fixes: https://github.com/boskokg/flutter_blue_plus/issues/177

The bluetooth scanner Dart API does not expose the current state of the isScanning stream.
We only have access to a Stream<bool>, even though the underlying StreamController is a BehaviorSubject.