### PR TITLE
scan timeout timer property so can be cancelled

### DIFF
--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -121,6 +121,9 @@ class FlutterBluePlus {
         .then((p) => p.map((d) => BluetoothDevice.fromProto(d)).toList());
   }
 
+  // timeout for scanning that can be cancelled by stopScan
+  Timer? _scanTimeout;
+
   /// Starts a scan for Bluetooth Low Energy devices and returns a stream
   /// of the [ScanResult] results as they are received.
   ///
@@ -149,7 +152,7 @@ class FlutterBluePlus {
     _isScanning.add(true);
 
     if (timeout != null) {
-      Future.delayed(timeout, () {
+      _scanTimeout = Timer(timeout, () {
         _isScanning.add(false);
         _channel.invokeMethod('stopScan');
       });
@@ -218,6 +221,7 @@ class FlutterBluePlus {
   /// Stops a scan for Bluetooth Low Energy devices
   Future stopScan() async {
     await _channel.invokeMethod('stopScan');
+    _scanTimeout?.cancel();
     _isScanning.add(false);
   }
 


### PR DESCRIPTION
The current method of calling stopScan on timeout causes a rogue Future if `stopScan()` if called whilst scanning, that causes erroneous stops.

For example:

1. call `startScan(timeout: 20)`
2. call after 10 seconds `stopScan()`.
3. call `startScan(timeout: 20)`
4. scan will stop due to first timeout Future after 10 seconds not 20.
5. call `startScan()`.
6. scan will stop after 10 seconds due to second call timeout even though no timeout desired.

This adds a Timer property to the class such that `stopScan()` can cancel it and prevent this behaviour.