### PR TITLE
Update guid.dart

### DIFF
--- a/lib/src/guid.dart
+++ b/lib/src/guid.dart
@@ -30,6 +30,11 @@ class Guid {
   }
 
   static List<int> _fromString(String input) {
+    // If input has empty value assign a default value 
+    if(input.isEmpty) {
+      input = "00000000-0000-0000-0000-000000000000";
+    }
+    
     input = _removeNonHexCharacters(input);
     final bytes = _hexDecode(input);
 


### PR DESCRIPTION
We have found the error "FormatException: The format is invalid" using some android 8 and previous Samsung devices. We found this error during the discovery services when some serviceUuid is an empty string. We thought to add a default all zeros uuid in the Guid._fromString.