### PR TITLE
handle ACCESS FINE LOCATION on Android 12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,25 @@ In the **android/app/src/main/AndroidManifest.xml** let’s add:
 ```xml
 	  <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
 	  <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-	  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
  <application
+```
+
+By default the package does not request the ACCESS_FINE_LOCATION permission on Android 12+. In case you need to get the physical
+location of the device via Bluetooth, you need to add the permission to the **android/app/src/main/AndroidManifest.xml**:
+
+```xml
+	  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+ <application
+```
+
+and set the androidUsesFineLocation flag to true when scanning:
+
+```dart
+// Start scanning
+flutterBlue.startScan(timeout: Duration(seconds: 4), androidUsesFineLocation: true);
+
+// Stop scanning
+flutterBlue.stopScan();
 ```
 
 #### **IOS**

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
     -->
   <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
   <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
   <!-- legacy for Android 11 or lower -->
   <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
   <!-- legacy for Android 11 or lower -->
   <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30"/>
 
 
   <!-- legacy for Android 9 or lower -->

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -9,11 +9,11 @@
      -->
    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
  
    <!-- legacy for Android 11 or lower -->
    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30"/>
  
    <!-- legacy for Android 9 or lower -->
    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="28" />

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
    <!-- legacy for Android 11 or lower -->
    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+   <!-- remove the maxSdkVersion restriction to access location information via Bluetooth on Android Version >=31 -->
    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30"/>
  
    <!-- legacy for Android 9 or lower -->

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -110,8 +110,10 @@ class FindDevicesScreen extends StatelessWidget {
         ],
       ),
       body: RefreshIndicator(
-        onRefresh: () => FlutterBluePlus.instance
-            .startScan(timeout: const Duration(seconds: 4)),
+        onRefresh: () => FlutterBluePlus.instance.startScan(
+            timeout: const Duration(seconds: 4),
+            androidUsesFineLocation:
+                false), // if set to true add permission ACCESS_FINE_LOCATION to AndroidManifest.xml
         child: SingleChildScrollView(
           child: Column(
             children: <Widget>[
@@ -180,8 +182,10 @@ class FindDevicesScreen extends StatelessWidget {
           } else {
             return FloatingActionButton(
                 child: const Icon(Icons.search),
-                onPressed: () => FlutterBluePlus.instance
-                    .startScan(timeout: const Duration(seconds: 4)));
+                onPressed: () => FlutterBluePlus.instance.startScan(
+                    timeout: const Duration(seconds: 4),
+                    androidUsesFineLocation:
+                        false)); // if set to true add permission ACCESS_FINE_LOCATION to AndroidManifest.xml
           }
         },
       ),

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -138,6 +138,10 @@ class FlutterBluePlus {
   /// timeout calls stopStream after a specified [Duration].
   /// You can also get a list of ongoing results in the [scanResults] stream.
   /// If scanning is already in progress, this will throw an [Exception].
+  ///
+  /// set [androidUsesFineLocation] to true if you want to derive the physical location of the device
+  /// on Android Version >=31 (Android 12). You need to add the following permission to your AndroidManifest.xml:
+  /// <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   Stream<ScanResult> scan({
     ScanMode scanMode = ScanMode.lowLatency,
     List<Guid> withServices = const [],
@@ -145,7 +149,7 @@ class FlutterBluePlus {
     List<String> macAddresses = const [],
     Duration? timeout,
     bool allowDuplicates = false,
-    bool androidUsesFineLocation = true,
+    bool androidUsesFineLocation = false,
   }) async* {
     var settings = BmScanSettings(
         serviceUuids: withServices.map((g) => g.toString()).toList(),
@@ -217,6 +221,10 @@ class FlutterBluePlus {
   ///
   /// To observe the results while the scan is in progress, listen to the [scanResults] stream,
   /// or call [scan] instead.
+  ///
+  /// set [androidUsesFineLocation] to true if you want to derive the physical location of the device
+  /// on Android Version >=31 (Android 12). You need to add the following permission to your AndroidManifest.xml:
+  /// <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   Future startScan({
     ScanMode scanMode = ScanMode.lowLatency,
     List<Guid> withServices = const [],
@@ -224,7 +232,7 @@ class FlutterBluePlus {
     List<String> macAddresses = const [],
     Duration? timeout,
     bool allowDuplicates = false,
-    bool androidUsesFineLocation = true,
+    bool androidUsesFineLocation = false,
   }) async {
     await scan(
             scanMode: scanMode,


### PR DESCRIPTION
After inspection i've found that we do not need the ACCESS_FINE_LOCATION permission on Android 12+. But we are requesting it by default in the startScan and scan method. I've set the default to false as this flag only concerns Android 12+ (lower is always requesting fine location) and updated the example, the comments and the readME.