### PR TITLE
New Feature - Scan continuously

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -180,12 +180,22 @@ class FindDevicesScreen extends StatelessWidget {
               backgroundColor: Colors.red,
             );
           } else {
+            /// previously method
+            // return FloatingActionButton(
+            //     child: const Icon(Icons.search),
+            //     onPressed: () => FlutterBluePlus.instance.startScan(
+            //         timeout: const Duration(seconds: 4),
+            //         androidUsesFineLocation:
+            //             false)); // if set to true add permission ACCESS_FINE_LOCATION to AndroidManifest.xml
+            /// Scan without timeout and with updateInterval.
             return FloatingActionButton(
                 child: const Icon(Icons.search),
                 onPressed: () => FlutterBluePlus.instance.startScan(
-                    timeout: const Duration(seconds: 4),
+                    updateInterval: const Duration(seconds: 1),
+                    expiredInterval: const Duration(seconds: 5),
+                    allowDuplicates: true,
                     androidUsesFineLocation:
-                        false)); // if set to true add permission ACCESS_FINE_LOCATION to AndroidManifest.xml
+                    false));
           }
         },
       ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -36,7 +36,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.7.3"
+    version: "1.7.5"
   js:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixed issue:
[BLE Scan Continuously #334 ](https://github.com/boskokg/flutter_blue_plus/issues/334)

Added:
- Add new params(updateInterval, expiredInterval) with scan. 

Updated:
- Update example to scan continuously

Set updateInterval, expiredInterval, and allowDuplicates=true, for fixing situations that may cause an error:
1. Discovered a bluetooth device and it in scan results.
2. Power-off the device to simulate the device have been leaved scene.
3. The device still in discovered list(scan results). So user can connect the device, but will never get success.