### PR TITLE
[Android] fix JSON success value is boolean

### DIFF
--- a/lib/src/bluetooth_msgs.dart
+++ b/lib/src/bluetooth_msgs.dart
@@ -570,7 +570,7 @@ class BmWriteDescriptorResponse {
     _printDbg("\nBmWriteDescriptorResponse $json");
     return BmWriteDescriptorResponse(
       request: BmWriteDescriptorRequest.fromMap(json['request']),
-      success: json['success'] != 0,
+      success: json['success'],
     );
   }
 }


### PR DESCRIPTION
The `WriteCharacteristicResponse` returns a boolean as the success value, not a number. Therefore, the check `json['success'] != 0` will always evaluate to true, even if the peripheral responded with an error.

```
WriteCharacteristicResponse:
 {request={service_uuid=dd3f469f-10c2-403f-94b0-79f46a288d00, remote_id=6A:44:8B:60:D8:35, characteristic_uuid=dd3f469f-10c2-403f-94b0-79f46a288d0a, write_type=0, value=}, success=false}
```