### PR TITLE
iOS, MacOS: fixed ScanResult.advertisementData.serviceUuids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 1.9.5
+* iOS, MacOS: fixed ScanResult.advertisementData.serviceUuids
+
 ## 1.9.4
-* iOS: fix characteristic read not working. (regression in 1.9.0
+* iOS: fix characteristic read not working. (regression in 1.9.0)
 * dart: handle device.readRssi failure in rssiStream gracefully
 
 ## 1.9.3

--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -1283,7 +1283,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     
     // Service Uuids - convert from CBUUID's to UUID strings
     NSArray *serviceUuidsB = nil;
-    if (serviceData != nil) {
+    if (serviceUuids != nil) {
         NSMutableArray *mutable = [[NSMutableArray alloc] init];
         for (CBUUID *uuid in serviceUuids) {
             [mutable addObject:uuid.UUIDString];

--- a/ios/flutter_blue_plus.podspec
+++ b/ios/flutter_blue_plus.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_blue_plus'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'Flutter plugin for connecting and communicationg with Bluetooth Low Energy devices, on Android and iOS'
   s.description      = 'Flutter plugin for connecting and communicationg with Bluetooth Low Energy devices, on Android and iOS'
   s.homepage         = 'https://github.com/boskokg/flutter_blue_plus'

--- a/macos/flutter_blue_plus.podspec
+++ b/macos/flutter_blue_plus.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_blue_plus'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'Flutter plugin for connecting and communicationg with Bluetooth Low Energy devices, on Android and iOS'
   s.description      = 'Flutter plugin for connecting and communicationg with Bluetooth Low Energy devices, on Android and iOS'
   s.homepage         = 'https://github.com/boskokg/flutter_blue_plus'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_blue_plus
 description: Flutter plugin for connecting and communicationg with Bluetooth Low Energy devices, on Android and iOS
-version: 1.9.4
+version: 1.9.5
 homepage: https://github.com/boskokg/flutter_blue_plus
 
 environment:


### PR DESCRIPTION
Fix for https://github.com/boskokg/flutter_blue_plus/issues/415

It looks like a typo in `ios/Classes/FlutterBluePlusPlugin.m` for both iOS and MacOS.