### PR TITLE
ignore MTU on characteristic write

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 FlutterBluePlus is a Bluetooth Low Energy plugin for [Flutter](https://flutter.dev).
 
-**Bluetooth Classic is not supported.** 
+**Bluetooth Classic is not supported.**
 
 (i.e. speakers, headphones, mice, keyboards, gamepads, and more are not supported).
 
@@ -41,11 +41,11 @@ This makes FlutterBluePlus very stable.
 
 ### Error Handling :fire:
 
-Flutter Blue Plus takes error handling very seriously. 
+Flutter Blue Plus takes error handling very seriously.
 
 Every error returned by the native platform is checked and thrown as an exception where appropriate. See [Reference](#reference) for a list of throwable functions.
 
-**Streams:** At the time of writing, streams returned by Flutter Blue Plus never emit any errors and never close. There's no need to handle `onError` or `onDone` for  `stream.listen(...)`.
+**Streams:** At the time of writing, streams returned by Flutter Blue Plus never emit any errors and never close. There's no need to handle `onError` or `onDone` for `stream.listen(...)`.
 
 ---
 
@@ -236,6 +236,7 @@ https://developer.android.com/about/versions/12/features/bluetooth-permissions -
 ```
 
 And set androidUsesFineLocation when scanning:
+
 ```dart
 // Start scanning
 flutterBlue.startScan(timeout: Duration(seconds: 4), androidUsesFineLocation: true);
@@ -282,7 +283,7 @@ For location permissions on iOS see more at: [https://developer.apple.com/docume
 ### FlutterBlue API
 
 |                        |      Android       |        iOS         | Throws | Description                                                |
-| :--------------------- | :----------------: | :----------------: | :----: | :----------------------------------------------------------|
+| :--------------------- | :----------------: | :----------------: | :----: | :--------------------------------------------------------- |
 | adapterState           | :white_check_mark: | :white_check_mark: |        | Stream of state changes for the bluetooth adapter          |
 | isAvailable            | :white_check_mark: | :white_check_mark: |        | Checks whether the device supports Bluetooth               |
 | isOn                   | :white_check_mark: | :white_check_mark: |        | Checks if Bluetooth adapter is turned on                   |
@@ -300,7 +301,7 @@ For location permissions on iOS see more at: [https://developer.apple.com/docume
 ### BluetoothDevice API
 
 |                           |      Android       |        iOS         | Throws | Description                                                |
-| :------------------------ | :----------------: | :----------------: | :----: | :----------------------------------------------------------|
+| :------------------------ | :----------------: | :----------------: | :----: | :--------------------------------------------------------- |
 | localName                 | :white_check_mark: | :white_check_mark: |        | The cached localName of the device                         |
 | connect                   | :white_check_mark: | :white_check_mark: | :fire: | Establishes a connection to the device                     |
 | disconnect                | :white_check_mark: | :white_check_mark: | :fire: | Cancels an active or pending connection to the device      |
@@ -320,27 +321,27 @@ For location permissions on iOS see more at: [https://developer.apple.com/docume
 
 ### BluetoothCharacteristic API
 
-|                 |      Android       |        iOS         | Throws | Description                                                    |
-| :-------------  | :----------------: | :----------------: | :----: | :--------------------------------------------------------------|
-| uuid            | :white_check_mark: | :white_check_mark: |        | The uuid of characeristic                                      |
-| read            | :white_check_mark: | :white_check_mark: | :fire: | Retrieves the value of the characteristic                      |
-| write           | :white_check_mark: | :white_check_mark: | :fire: | Writes the value of the characteristic                         |
-| setNotifyValue  | :white_check_mark: | :white_check_mark: | :fire: | Sets notifications or indications on the characteristic        |
-| isNotifying     | :white_check_mark: | :white_check_mark: |        | Are notifications or indications currently enabled             |
-| onValueReceived | :white_check_mark: | :white_check_mark: |        | Stream of characteristic value updates received from the device|
-| lastValue       | :white_check_mark: | :white_check_mark: |        | The most recent value of the characteristic                    |
-| lastValueStream | :white_check_mark: | :white_check_mark: |        | Stream of lastValue + onValueReceived                          |
+|                 |      Android       |        iOS         | Throws | Description                                                     |
+| :-------------- | :----------------: | :----------------: | :----: | :-------------------------------------------------------------- |
+| uuid            | :white_check_mark: | :white_check_mark: |        | The uuid of characeristic                                       |
+| read            | :white_check_mark: | :white_check_mark: | :fire: | Retrieves the value of the characteristic                       |
+| write           | :white_check_mark: | :white_check_mark: | :fire: | Writes the value of the characteristic                          |
+| setNotifyValue  | :white_check_mark: | :white_check_mark: | :fire: | Sets notifications or indications on the characteristic         |
+| isNotifying     | :white_check_mark: | :white_check_mark: |        | Are notifications or indications currently enabled              |
+| onValueReceived | :white_check_mark: | :white_check_mark: |        | Stream of characteristic value updates received from the device |
+| lastValue       | :white_check_mark: | :white_check_mark: |        | The most recent value of the characteristic                     |
+| lastValueStream | :white_check_mark: | :white_check_mark: |        | Stream of lastValue + onValueReceived                           |
 
 ### BluetoothDescriptor API
 
-|                   |      Android       |        iOS         | Throws | Description                                    |
-| :----             | :----------------: | :----------------: | :----: | :----------------------------------------------|
-| uuid              | :white_check_mark: | :white_check_mark: |        | The uuid of descriptor                         |
-| read              | :white_check_mark: | :white_check_mark: | :fire: | Retrieves the value of the descriptor          |
-| write             | :white_check_mark: | :white_check_mark: | :fire: | Writes the value of the descriptor             |
-| onValueReceived   | :white_check_mark: | :white_check_mark: |        | Stream of descriptor value reads & writes      |
-| lastValue         | :white_check_mark: | :white_check_mark: |        | The most recent value of the descriptor        |
-| lastValueStream   | :white_check_mark: | :white_check_mark: |        | Stream of lastValue + onValueReceived          |
+|                 |      Android       |        iOS         | Throws | Description                               |
+| :-------------- | :----------------: | :----------------: | :----: | :---------------------------------------- |
+| uuid            | :white_check_mark: | :white_check_mark: |        | The uuid of descriptor                    |
+| read            | :white_check_mark: | :white_check_mark: | :fire: | Retrieves the value of the descriptor     |
+| write           | :white_check_mark: | :white_check_mark: | :fire: | Writes the value of the descriptor        |
+| onValueReceived | :white_check_mark: | :white_check_mark: |        | Stream of descriptor value reads & writes |
+| lastValue       | :white_check_mark: | :white_check_mark: |        | The most recent value of the descriptor   |
+| lastValueStream | :white_check_mark: | :white_check_mark: |        | Stream of lastValue + onValueReceived     |
 
 ## Debugging
 
@@ -370,7 +371,7 @@ Many common problems are easily solved.
 
 **1. your device uses bluetooth classic, not BLE.**
 
-Headphones, speakers, keyboards, mice, gamepads, & printers all use Bluetooth Classic. 
+Headphones, speakers, keyboards, mice, gamepads, & printers all use Bluetooth Classic.
 
 These devices may be found in System Settings, but they cannot be connected to by FlutterBluePlus. FlutterBluePlus only supports Bluetooth Low Energy.
 
@@ -400,12 +401,29 @@ for (var d in system) {
 - try removing all scan filters
 - for `withServices` to work, your device must actively advertise the serviceUUIDs it supports
 
-
 **4. try a ble scanner app**
 
-Search the App Store for a BLE scanner apps. 
+Search the App Store for a BLE scanner apps.
 
 You should check if they can discover your device.
+
+**5. your write request (without response) does not work**
+
+Check out if the amount of bytes fits the defined MTU size. The MTU size is received on connection. Try to change the necessary MTU size by calling
+
+```
+await device.requestMtu(512);
+```
+
+or change the size of your byte array to fit the MTU size.
+
+In case you can not negotiate a different MTU size and you also do not want to shrink the size of your byte array, you can explicitely ignore the MTU size on writing data.
+
+Only do this, if you are **SURE** that the receiving device can handle it (e.g. because the hardware developer told you so).
+
+```
+c.write([0x12, 0x34], ignoreMtuRestriction: true);
+```
 
 ---
 
@@ -429,15 +447,6 @@ Try interacting with your device to get it to send new data.
 
 **4. your device has bugs**
 
-Try rebooting your ble device. 
+Try rebooting your ble device.
 
 Some ble devices have buggy software and stop sending data.
-
-
-
-
-
-
-
-
-

--- a/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/boskokg/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -543,6 +543,7 @@ public class FlutterBluePlusPlugin implements
                     String characteristicUuid =   (String) data.get("characteristic_uuid");
                     String value =                (String) data.get("value");
                     int writeTypeInt =               (int) data.get("write_type");
+                    int ignoreMtuRestriction =       (int) data.get("ignore_mtu_restriction"); // 0 = false, 1 = true
 
                     int writeType = writeTypeInt == 0 ?
                         BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT :
@@ -568,13 +569,15 @@ public class FlutterBluePlusPlugin implements
                         }
                     }
 
-                    // check mtu
-                    int mtu = mMtu.get(remoteId);
-                    if ((mtu-3) < hexToBytes(value).length) {
-                        String s = "data longer than mtu allows. dataLength: " +
-                            hexToBytes(value).length + "> max: " + (mtu-3);
-                        result.error("write_characteristic_error", s, null);
-                        break;
+                    // check mtu if not ignored
+                    if (ignoreMtuRestriction == 0) {
+                        int mtu = mMtu.get(remoteId);
+                        if ((mtu-3) < hexToBytes(value).length) {
+                            String s = "data longer than mtu allows. dataLength: " +
+                                hexToBytes(value).length + "> max: " + (mtu-3);
+                            result.error("write_characteristic_error", s, null);
+                            break;
+                        }
                     }
 
                     // Version 33

--- a/lib/src/bluetooth_msgs.dart
+++ b/lib/src/bluetooth_msgs.dart
@@ -1,6 +1,5 @@
 part of flutter_blue_plus;
 
-
 enum BmAdapterStateEnum {
   unknown,
   unavailable,
@@ -155,9 +154,11 @@ class BmScanResult {
   factory BmScanResult.fromMap(Map<dynamic, dynamic> json) {
     return BmScanResult(
       device: BmBluetoothDevice.fromMap(json['device']),
-      advertisementData: BmAdvertisementData.fromMap(json['advertisement_data']),
+      advertisementData:
+          BmAdvertisementData.fromMap(json['advertisement_data']),
       rssi: json['rssi'],
-      connectionState: BmConnectionStateEnum.values[json['connection_state'] as int],
+      connectionState:
+          BmConnectionStateEnum.values[json['connection_state'] as int],
     );
   }
 }
@@ -173,8 +174,10 @@ class BmScanResponse {
 
   factory BmScanResponse.fromMap(Map<dynamic, dynamic> json) {
     return BmScanResponse(
-      result: json['result'] != null ? BmScanResult.fromMap(json['result']) : null,
-      failed: json['failed'] != null ? BmScanFailed.fromMap(json['failed']) : null,
+      result:
+          json['result'] != null ? BmScanResult.fromMap(json['result']) : null,
+      failed:
+          json['failed'] != null ? BmScanFailed.fromMap(json['failed']) : null,
     );
   }
 }
@@ -247,7 +250,6 @@ class BmBluetoothService {
   });
 
   factory BmBluetoothService.fromMap(Map<dynamic, dynamic> json) {
-
     // convert characteristics
     List<BmBluetoothCharacteristic> chrs = [];
     for (var v in json['characteristics']) {
@@ -290,7 +292,6 @@ class BmBluetoothCharacteristic {
   });
 
   factory BmBluetoothCharacteristic.fromMap(Map<dynamic, dynamic> json) {
-
     // convert descriptors
     List<BmBluetoothDescriptor> descs = [];
     for (var v in json['descriptors']) {
@@ -300,7 +301,9 @@ class BmBluetoothCharacteristic {
     return BmBluetoothCharacteristic(
       remoteId: json['remote_id'],
       serviceUuid: Guid(json['service_uuid']),
-      secondaryServiceUuid: json['secondary_service_uuid'] != null ? Guid(json['secondary_service_uuid']) : null,
+      secondaryServiceUuid: json['secondary_service_uuid'] != null
+          ? Guid(json['secondary_service_uuid'])
+          : null,
       characteristicUuid: Guid(json['characteristic_uuid']),
       descriptors: descs,
       properties: BmCharacteristicProperties.fromMap(json['properties']),
@@ -452,7 +455,9 @@ class BmOnCharacteristicReceived {
     return BmOnCharacteristicReceived(
       remoteId: json['remote_id'],
       serviceUuid: Guid(json['service_uuid']),
-      secondaryServiceUuid: json['secondary_service_uuid'] != null ? Guid(json['secondary_service_uuid']) : null,
+      secondaryServiceUuid: json['secondary_service_uuid'] != null
+          ? Guid(json['secondary_service_uuid'])
+          : null,
       characteristicUuid: Guid(json['characteristic_uuid']),
       value: _hexDecode(json['value']),
       success: json['success'] != 0,
@@ -485,7 +490,9 @@ class BmOnCharacteristicWritten {
     return BmOnCharacteristicWritten(
       remoteId: json['remote_id'],
       serviceUuid: Guid(json['service_uuid']),
-      secondaryServiceUuid: json['secondary_service_uuid'] != null ? Guid(json['secondary_service_uuid']) : null,
+      secondaryServiceUuid: json['secondary_service_uuid'] != null
+          ? Guid(json['secondary_service_uuid'])
+          : null,
       characteristicUuid: Guid(json['characteristic_uuid']),
       success: json['success'] != 0,
       errorCode: json['error_code'],
@@ -525,12 +532,18 @@ enum BmWriteType {
   withoutResponse,
 }
 
+enum BmWriteIgnoreMtuRestrictionType {
+  no,
+  yes,
+}
+
 class BmWriteCharacteristicRequest {
   final String remoteId;
   final Guid serviceUuid;
   final Guid? secondaryServiceUuid;
   final Guid characteristicUuid;
   final BmWriteType writeType;
+  final BmWriteIgnoreMtuRestrictionType ignoreMtuRestriction;
   final List<int> value;
 
   BmWriteCharacteristicRequest({
@@ -540,6 +553,7 @@ class BmWriteCharacteristicRequest {
     required this.characteristicUuid,
     required this.writeType,
     required this.value,
+    required this.ignoreMtuRestriction,
   });
 
   Map<dynamic, dynamic> toMap() {
@@ -550,6 +564,7 @@ class BmWriteCharacteristicRequest {
     data['characteristic_uuid'] = characteristicUuid.toString();
     data['write_type'] = writeType.index;
     data['value'] = _hexEncode(value);
+    data['ignore_mtu_restriction'] = ignoreMtuRestriction.index;
     return data;
   }
 }
@@ -628,7 +643,9 @@ class BmOnDescriptorResponse {
       type: bmOnDescriptorResponseParse(json['type']),
       remoteId: json['remote_id'],
       serviceUuid: Guid(json['service_uuid']),
-      secondaryServiceUuid: json['secondary_service_uuid'] != null ? Guid(json['secondary_service_uuid']) : null,
+      secondaryServiceUuid: json['secondary_service_uuid'] != null
+          ? Guid(json['secondary_service_uuid'])
+          : null,
       characteristicUuid: Guid(json['characteristic_uuid']),
       descriptorUuid: Guid(json['descriptor_uuid']),
       value: _hexDecode(json['value']),
@@ -691,7 +708,8 @@ class BmConnectionStateResponse {
   factory BmConnectionStateResponse.fromMap(Map<dynamic, dynamic> json) {
     return BmConnectionStateResponse(
       remoteId: json['remote_id'],
-      connectionState: BmConnectionStateEnum.values[json['connection_state'] as int],
+      connectionState:
+          BmConnectionStateEnum.values[json['connection_state'] as int],
     );
   }
 }


### PR DESCRIPTION
I ran into a problem with the added MTU Size check in the 'writeCharacteristic' method.

I develop an App for one specific device and the MTU Size i get from the device is the minimum size 23. I know from the hardware developer that i can and should send a larger byte array to speed up data transer. Negotiating a different MTU size by requesting it keeps failing. 

So i came up with a "ignoreMtuRestriction" flag in the write method to explicitely ignore the MTU size as i know for sure that the receiving client can handle that byte array size. 
```
await c.write([0x12, 0x13], ignoreMtuRestriction: true);
```

I've tested it on Android & iOS. I also added this (very special) case to the readMe in the Debugging section.

unfortunately my IDE keeps re-formatting your code, so a lot of format changes, sorry.