### PR TITLE
[iOS] fix: manufacturer data not parsed if only company ID is present

### DIFF
--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -1232,7 +1232,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
     // Manufacturer Data
     NSDictionary* manufDataB = nil;
-    if (manufData != nil && manufData.length > 2) {
+    if (manufData != nil && manufData.length >= 2) {
         
         // first 2 bytes are manufacturerId
         unsigned short manufId = 0;


### PR DESCRIPTION
Manufacturer data may only include the company ID (16 bits). We still want to parse it in this case.

See also:
https://github.com/pauldemarco/flutter_blue/pull/293/commits/bd6071fcd78ecdff61a6f64d3546aafb090cc0bf