### PR TITLE
Hot fix for crash on iOS while discovering services

### DIFF
--- a/ios/Classes/FlutterBluePlusPlugin.m
+++ b/ios/Classes/FlutterBluePlusPlugin.m
@@ -1587,8 +1587,16 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     {
         NSData* data = nil;
         if (d.value) {
-            int value = [d.value intValue];
-            data = [NSData dataWithBytes:&value length:sizeof(value)];
+            @try {
+                  if  ([d.value isKindOfClass:NSNumber.class]) {
+                      int value = [d.value intValue];
+                      data = [NSData dataWithBytes:&value length:sizeof(value)];
+                  }else if([d.value isKindOfClass:NSData.class]) {
+                      data = d.value;
+                  }
+              } @catch (NSException *exception) {
+                  NSLog(@"%@", exception.reason);
+              }
         }
     
         // See: BmBluetoothDescriptor


### PR DESCRIPTION
There was a crashed forced by an unknown selector: [_NSInlineData intValue]: unrecognized selector sent to instance 

I fixed this by adding a check for the class type. 

A merge would be appreciated. 

This is related to: https://github.com/pauldemarco/flutter_blue/issues/1092

Best,
Toni