### PR TITLE
Android: "getAdapterName" requires bluetooth-permissions

### DIFF
--- a/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -293,8 +293,22 @@ public class FlutterBluePlusPlugin implements
 
                case "getAdapterName":
                 {
-                    String adapterName = mBluetoothAdapter != null ? mBluetoothAdapter.getName() : "N/A";
-                    result.success(adapterName != null ? adapterName : "");
+                    ArrayList<String> permissions = new ArrayList<>();
+
+                    if (Build.VERSION.SDK_INT >= 31) { // Android 12 (October 2021)
+                        permissions.add(Manifest.permission.BLUETOOTH_CONNECT);
+                    }
+
+                    if (Build.VERSION.SDK_INT <= 30) { // Android 11 (September 2020)
+                        permissions.add(Manifest.permission.BLUETOOTH);
+                    }
+
+                    ensurePermissions(permissions, (granted, perm) -> {
+
+                        String adapterName = mBluetoothAdapter != null ? mBluetoothAdapter.getName() : "N/A";
+                        result.success(adapterName != null ? adapterName : "");
+
+                    });
                     break;
                 }
 


### PR DESCRIPTION
"getAdapterName" needs already bluetooth-permissions, at least under Android; if not any other function ("connect", "turnon" etc.) which requests permission is called before, call of "getAdapterName" ends in an exception.

Therefore "ensurePermissions"-code added before calling mBluetoothAdapter.getName().
