### PR TITLE
[Fix] android requires full UUIDs

### DIFF
--- a/lib/src/bluetooth_msgs.dart
+++ b/lib/src/bluetooth_msgs.dart
@@ -83,7 +83,7 @@ class BmScanSettings {
 
   Map<dynamic, dynamic> toMap() {
     final Map<dynamic, dynamic> data = {};
-    data['with_services'] = withServices.map((s) => s.uuid).toList();
+    data['with_services'] = withServices.map((s) => s.uuid128).toList();
     data['with_remote_ids'] = withRemoteIds;
     data['with_names'] = withNames;
     data['with_keywords'] = withKeywords;


### PR DESCRIPTION
### Details

Android requires full 128-bit UUIDs for interacting with devices. This PR updates `BmScanSettings.toMap()` to use `.uuid128`. There are other instances of `.uuid` in `bluetooth_msgs.dart` which probably have the same issue, but I don't have use cases to test those out yet. If you can provide use cases, I can try to update those as well.

### Testing

(Android only)
I've manually tested this with the example app by updating `example\lib\screens\scan_screen.dart` like:
```dart
// example\lib\screens\scan_screen.dart
...
Guid _guidMeshProvisioningService = Guid("1827");
Guid _guidMeshProxyService = Guid("00001828-0000-1000-8000-00805f9b34fb");
...
  Future onScanPressed() async {
    try {
      // android is slow when asking for all advertisments,
      // so instead we only ask for 1/8 of them
      int divisor = Platform.isAndroid ? 8 : 1;
      await FlutterBluePlus.startScan(
        timeout: const Duration(seconds: 15),
        continuousUpdates: true,
        continuousDivisor: divisor,
        withServices: [
          _guidMeshProvisioningService,
          _guidMeshProxyService,
        ],
      );
    } catch (e) {
      Snackbar.show(ABC.b, prettyException("Start Scan Error:", e), success: false);
    }
    setState(() {}); // force refresh of systemDevices
  }
...
```

Closes #670 