### PR TITLE
[Android] Compare both short versions of UUID in getDescriptorFromArray

### DIFF
--- a/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -1571,7 +1571,7 @@ public class FlutterBluePlusPlugin implements
     private BluetoothGattDescriptor getDescriptorFromArray(String uuid, List<BluetoothGattDescriptor> array)
     {
         for (BluetoothGattDescriptor d : array) {
-            if (uuidStr(d.getUuid()).equals(uuid)) {
+            if (uuidStr(d.getUuid()).equals(uuidStr(UUID.fromString(uuid)))) {
                 return d;
             }
         }


### PR DESCRIPTION
When looking for descriptor we are trying to compare the short version of the UUID with the long one so if never found. Sorting both of them