### PR TITLE
Added matching of serviceUuid during characteristic search

### DIFF
--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -291,9 +291,11 @@ class BluetoothCharacteristic {
   BmBluetoothCharacteristic? get _bmchr {
     if (FlutterBluePlus._knownServices[remoteId] != null) {
       for (var s in FlutterBluePlus._knownServices[remoteId]!.services) {
-        for (var c in s.characteristics) {
-          if (c.characteristicUuid == uuid) {
-            return c;
+        if (s.serviceUuid == serviceUuid) {
+          for (var c in s.characteristics) {
+            if (c.characteristicUuid == uuid) {
+              return c;
+            }
           }
         }
       }


### PR DESCRIPTION
Issue appear when I tried to crate descriptors for my characteristics with same uuid but under different services with different uuid. As result I had descriptor for all characteristics but only from first one, even if characteristic has another descriptor with another uuid or doesn't have any descriptors. With next code everything works as expected.