### PR TITLE
[Android] Type casting error when start scan

### DIFF
--- a/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -1879,7 +1879,7 @@ public class FlutterBluePlusPlugin implements
                     }
 
                     // filter divisor
-                    if (((boolean) mScanFilters.get("continuous_updates")) == false) {
+                    if (((boolean) mScanFilters.get("continuous_updates")) != false) {
                         int count = scanCountIncrement(remoteId);   
                         if ((count % (int) mScanFilters.get("continuous_divisor")) != 0) {
                             return;

--- a/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -1879,7 +1879,7 @@ public class FlutterBluePlusPlugin implements
                     }
 
                     // filter divisor
-                    if (((int) mScanFilters.get("continuous_updates")) != 0) {
+                    if (((boolean) mScanFilters.get("continuous_updates")) == false) {
                         int count = scanCountIncrement(remoteId);   
                         if ((count % (int) mScanFilters.get("continuous_divisor")) != 0) {
                             return;


### PR DESCRIPTION
```
E/AndroidRuntime(30132): java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.Integer
E/AndroidRuntime(30132): at com.lib.flutter_blue_plus.FlutterBluePlusPlugin$3.onScanResult(FlutterBluePlusPlugin.java:1882)
E/AndroidRuntime(30132): at android.bluetooth.le.BluetoothLeScanner$BleScanCallbackWrapper$1.run(BluetoothLeScanner.java:646)
E/AndroidRuntime(30132): at android.os.Handler.handleCallback(Handler.java:900)
E/AndroidRuntime(30132): at android.os.Handler.dispatchMessage(Handler.java:103)
E/AndroidRuntime(30132): at android.os.Looper.loop(Looper.java:219)
E/AndroidRuntime(30132): at android.app.ActivityThread.main(ActivityThread.java:8673)
E/AndroidRuntime(30132): at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(30132): at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
E/AndroidRuntime(30132): at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1109)
```