### PR TITLE
`BluetoothConnectionState.disconnected` emitted before subscription is canceled when using `device.cancelWhenDisconnected` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ var subscription = device.connectionState.listen((BluetoothConnectionState state
     }
 });
 
+// Optionally: cancel subscription when state is disconnected and still get the last BluetoothConnectionState.disconnected
+device.cancelWhenDisconnected(subscription, next:true);
+
 // Connect to the device
 await device.connect();
 

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -519,6 +519,7 @@ class FlutterBluePlus {
       BmConnectionStateResponse r = BmConnectionStateResponse.fromMap(call.arguments);
       var remoteId = DeviceIdentifier(r.remoteId);
       if (r.connectionState == BmConnectionStateEnum.disconnected) {
+        await Future.delayed(Duration.zero);
         _deviceSubscriptions[remoteId]?.forEach((s) => s.cancel()); // cancel subscriptions
         _deviceSubscriptions.remove(remoteId); // delete subscriptions
       }


### PR DESCRIPTION
This PR fixes the `BluetoothConnectionState.disconnected` not being emitted before `device.connectionState` subscription is canceled when using `device.cancelWhenDisconnected(subscription, next: true);`.

See issue #758.