### PR TITLE
Skip linters on gradle build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,6 +11,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    lintOptions {
+        abortOnError false
+    }
+
     defaultConfig {
         minSdkVersion 21
     }


### PR DESCRIPTION
I found this Linter issue using Fastlane and building using Gradle: https://docs.fastlane.tools/actions/gradle/
The following command `./gradlew build -p . -s` failed

```
> Task :flutter_blue_plus:lintDebug FAILED
Lint found 41 errors, 3 warnings. First failure:

/root/.pub-cache/hosted/pub.dev/flutter_blue_plus-1.31.12/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java:205: Error: Missing permissions required by BluetoothLeScanner.stopScan: android.permission.BLUETOOTH_SCAN [MissingPermission]
                scanner.stopScan(getScanCallback());
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


```