### PR TITLE
Integrate L2Cap channels for Bluetooth.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 .packages
 build/
 .pub/
+local.properties
+example/local.properties

--- a/README.md
+++ b/README.md
@@ -597,46 +597,51 @@ You can try using https://pub.dev/packages/flutter_foreground_task or possibly h
 
 ### FlutterBluePlus API
 
-|                        |      Android       |        iOS         | Throws | Description                                                |
-| :--------------------- | :----------------: | :----------------: | :----: | :----------------------------------------------------------|
-| setLogLevel            | :white_check_mark: | :white_check_mark: |        | Configure plugin log level                                 |
-| setOptions             | :white_check_mark: | :white_check_mark: |        | Set configurable bluetooth options                         |
-| isSupported            | :white_check_mark: | :white_check_mark: |        | Checks whether the device supports Bluetooth               |
-| turnOn                 | :white_check_mark: |                    | :fire: | Turns on the bluetooth adapter                             |
-| adapterStateNow     ⚡  | :white_check_mark: | :white_check_mark: |        | Current state of the bluetooth adapter                     |
-| adapterState        🌀 | :white_check_mark: | :white_check_mark: |        | Stream of on & off states of the bluetooth adapter         |
-| startScan              | :white_check_mark: | :white_check_mark: | :fire: | Starts a scan for Ble devices                              |
-| stopScan               | :white_check_mark: | :white_check_mark: | :fire: | Stop an existing scan for Ble devices                      |
-| onScanResults       🌀 | :white_check_mark: | :white_check_mark: |        | Stream of live scan results                                |
-| scanResults         🌀 | :white_check_mark: | :white_check_mark: |        | Stream of live scan results or previous results            |
-| lastScanResults     ⚡  | :white_check_mark: | :white_check_mark: |        | The most recent scan results                               |
-| isScanning          🌀 | :white_check_mark: | :white_check_mark: |        | Stream of current scanning state                           |
-| isScanningNow       ⚡  | :white_check_mark: | :white_check_mark: |        | Is a scan currently running?                               |
-| connectedDevices    ⚡  | :white_check_mark: | :white_check_mark: |        | List of devices connected to *your app*                    |
-| systemDevices          | :white_check_mark: | :white_check_mark: | :fire: | List of devices connected to the system, even by other apps|
-| getPhySupport          | :white_check_mark: |                    | :fire: | Get supported bluetooth phy codings                        |
+|                        |      Android       |        iOS         | Throws | Description                                                       |
+|:-----------------------|:------------------:|:------------------:|:------:|:------------------------------------------------------------------|
+| setLogLevel            | :white_check_mark: | :white_check_mark: |        | Configure plugin log level                                        |
+| setOptions             | :white_check_mark: | :white_check_mark: |        | Set configurable bluetooth options                                |
+| isSupported            | :white_check_mark: | :white_check_mark: |        | Checks whether the device supports Bluetooth                      |
+| turnOn                 | :white_check_mark: |                    | :fire: | Turns on the bluetooth adapter                                    |
+| adapterStateNow     ⚡  | :white_check_mark: | :white_check_mark: |        | Current state of the bluetooth adapter                            |
+| adapterState        🌀 | :white_check_mark: | :white_check_mark: |        | Stream of on & off states of the bluetooth adapter                |
+| startScan              | :white_check_mark: | :white_check_mark: | :fire: | Starts a scan for Ble devices                                     |
+| stopScan               | :white_check_mark: | :white_check_mark: | :fire: | Stop an existing scan for Ble devices                             |
+| onScanResults       🌀 | :white_check_mark: | :white_check_mark: |        | Stream of live scan results                                       |
+| scanResults         🌀 | :white_check_mark: | :white_check_mark: |        | Stream of live scan results or previous results                   |
+| lastScanResults     ⚡  | :white_check_mark: | :white_check_mark: |        | The most recent scan results                                      |
+| isScanning          🌀 | :white_check_mark: | :white_check_mark: |        | Stream of current scanning state                                  |
+| isScanningNow       ⚡  | :white_check_mark: | :white_check_mark: |        | Is a scan currently running?                                      |
+| connectedDevices    ⚡  | :white_check_mark: | :white_check_mark: |        | List of devices connected to *your app*                           |
+| systemDevices          | :white_check_mark: | :white_check_mark: | :fire: | List of devices connected to the system, even by other apps       |
+| getPhySupport          | :white_check_mark: |                    | :fire: | Get supported bluetooth phy codings                               |
+| listenL2CapChannel     | :white_check_mark: | :white_check_mark: | :fire: | L2Cap: Opens a Server Socket and returns the PSM to this channel. |
+| closeL2CapServer       | :white_check_mark: | :white_check_mark: | :fire: | L2Cap: Closes a Server Socket with the provided PSM.              |
+
 
 ### FlutterBluePlus Events API
 
-|                                    |      Android       |        iOS         | Throws | Description                                           |
-| :--------------------------------- | :----------------: | :----------------: | :----: | :-----------------------------------------------------|
-| events.onConnectionStateChanged 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of connection changes of *all devices*         |
-| events.onMtuChanged             🌀 | :white_check_mark: | :white_check_mark: |        | Stream of mtu changes of *all devices*                |
-| events.onReadRssi               🌀 | :white_check_mark: | :white_check_mark: |        | Stream of rssi reads of *all devices*                 |
-| events.onServicesReset          🌀 | :white_check_mark: | :white_check_mark: |        | Stream of services resets of *all devices*            |
-| events.onDiscoveredServices     🌀 | :white_check_mark: | :white_check_mark: |        | Stream of services discovered of *all devices*        |
-| events.onCharacteristicReceived 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of characteristic value reads of *all devices* |
-| events.onCharacteristicWritten  🌀 | :white_check_mark: | :white_check_mark: |        | Stream of characteristic value writes of *all devices*|
-| events.onDescriptorRead         🌀 | :white_check_mark: | :white_check_mark: |        | Stream of descriptor value reads of *all devices*     |
-| events.onDescriptorWritten      🌀 | :white_check_mark: | :white_check_mark: |        | Stream of descriptor value writes of *all devices*    |
-| events.onBondStateChanged       🌀 | :white_check_mark: |                    |        | Stream of android bond state changes of *all devices* |
-| events.onNameChanged            🌀 |                    | :white_check_mark: |        | Stream of iOS name changes of *all devices*           |
+|                                    |      Android       |        iOS         | Throws | Description                                              |
+|:-----------------------------------|:------------------:|:------------------:|:------:|:---------------------------------------------------------|
+| events.onConnectionStateChanged 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of connection changes of *all devices*            |
+| events.onMtuChanged             🌀 | :white_check_mark: | :white_check_mark: |        | Stream of mtu changes of *all devices*                   |
+| events.onReadRssi               🌀 | :white_check_mark: | :white_check_mark: |        | Stream of rssi reads of *all devices*                    |
+| events.onServicesReset          🌀 | :white_check_mark: | :white_check_mark: |        | Stream of services resets of *all devices*               |
+| events.onDiscoveredServices     🌀 | :white_check_mark: | :white_check_mark: |        | Stream of services discovered of *all devices*           |
+| events.onCharacteristicReceived 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of characteristic value reads of *all devices*    |
+| events.onCharacteristicWritten  🌀 | :white_check_mark: | :white_check_mark: |        | Stream of characteristic value writes of *all devices*   |
+| events.onDescriptorRead         🌀 | :white_check_mark: | :white_check_mark: |        | Stream of descriptor value reads of *all devices*        |
+| events.onDescriptorWritten      🌀 | :white_check_mark: | :white_check_mark: |        | Stream of descriptor value writes of *all devices*       |
+| events.onBondStateChanged       🌀 | :white_check_mark: |                    |        | Stream of android bond state changes of *all devices*    |
+| events.onNameChanged            🌀 |                    | :white_check_mark: |        | Stream of iOS name changes of *all devices*              |
+| events.l2CapChannelConnected    🌀 | :white_check_mark: | :white_check_mark: |        | L2Cap: Device is connecting to an offered L2Cap channel. |
+
 
 
 ### BluetoothDevice API
 
 |                           |      Android       |        iOS         | Throws | Description                                                |
-| :------------------------ | :----------------: | :----------------: | :----: | :----------------------------------------------------------|
+|:--------------------------|:------------------:|:------------------:|:------:|:-----------------------------------------------------------|
 | platformName            ⚡ | :white_check_mark: | :white_check_mark: |        | The platform preferred name of the device                  |
 | advName                 ⚡ | :white_check_mark: | :white_check_mark: |        | The advertised name of the device found during scanning    |
 | connect                   | :white_check_mark: | :white_check_mark: | :fire: | Establishes a connection to the device                     |
@@ -657,30 +662,34 @@ You can try using https://pub.dev/packages/flutter_foreground_task or possibly h
 | removeBond                | :white_check_mark: |                    | :fire: | Remove Bluetooth Bond of device                            |
 | setPreferredPhy           | :white_check_mark: |                    | :fire: | Set preferred RX and TX phy for connection and phy options |
 | clearGattCache            | :white_check_mark: |                    | :fire: | Clear android cache of service discovery results           |
+| openL2CapChannel          | :white_check_mark: |                    | :fire: | L2Cap: Open a L2CAP channel to the Bluetooth Device        |
+| closeL2CapChannel         | :white_check_mark: | :white_check_mark: | :fire: | L2Cap: Close a L2CAP channel to the Bluetooth Device       |
+| readL2CapChannel          | :white_check_mark: | :white_check_mark: | :fire: | L2Cap: Read from a L2CAP channel                           |
+| writeL2CapChannel         | :white_check_mark: | :white_check_mark: | :fire: | L2Cap: Send bytes using the L2CAP channel with the PSM.    |
 
 ### BluetoothCharacteristic API
 
-|                    |      Android       |        iOS         | Throws | Description                                                    |
-| :----------------- | :----------------: | :----------------: | :----: | :--------------------------------------------------------------|
+|                    |      Android       |        iOS         | Throws | Description                                                     |
+|:-------------------|:------------------:|:------------------:|:------:|:----------------------------------------------------------------|
 | uuid             ⚡ | :white_check_mark: | :white_check_mark: |        | The uuid of characteristic                                      |
-| read               | :white_check_mark: | :white_check_mark: | :fire: | Retrieves the value of the characteristic                      |
-| write              | :white_check_mark: | :white_check_mark: | :fire: | Writes the value of the characteristic                         |
-| setNotifyValue     | :white_check_mark: | :white_check_mark: | :fire: | Sets notifications or indications on the characteristic        |
-| isNotifying      ⚡ | :white_check_mark: | :white_check_mark: |        | Are notifications or indications currently enabled             |
-| onValueReceived 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of characteristic value updates received from the device|
-| lastValue        ⚡ | :white_check_mark: | :white_check_mark: |        | The most recent value of the characteristic                    |
-| lastValueStream 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of onValueReceived + writes                             |
+| read               | :white_check_mark: | :white_check_mark: | :fire: | Retrieves the value of the characteristic                       |
+| write              | :white_check_mark: | :white_check_mark: | :fire: | Writes the value of the characteristic                          |
+| setNotifyValue     | :white_check_mark: | :white_check_mark: | :fire: | Sets notifications or indications on the characteristic         |
+| isNotifying      ⚡ | :white_check_mark: | :white_check_mark: |        | Are notifications or indications currently enabled              |
+| onValueReceived 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of characteristic value updates received from the device |
+| lastValue        ⚡ | :white_check_mark: | :white_check_mark: |        | The most recent value of the characteristic                     |
+| lastValueStream 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of onValueReceived + writes                              |
 
 ### BluetoothDescriptor API
 
-|                    |      Android       |        iOS         | Throws | Description                                    |
-| :----              | :----------------: | :----------------: | :----: | :----------------------------------------------|
-| uuid             ⚡ | :white_check_mark: | :white_check_mark: |        | The uuid of descriptor                         |
-| read               | :white_check_mark: | :white_check_mark: | :fire: | Retrieves the value of the descriptor          |
-| write              | :white_check_mark: | :white_check_mark: | :fire: | Writes the value of the descriptor             |
-| onValueReceived 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of descriptor value reads & writes      |
-| lastValue        ⚡ | :white_check_mark: | :white_check_mark: |        | The most recent value of the descriptor        |
-| lastValueStream 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of onValueReceived + writes             |
+|                    |      Android       |        iOS         | Throws | Description                               |
+|:-------------------|:------------------:|:------------------:|:------:|:------------------------------------------|
+| uuid             ⚡ | :white_check_mark: | :white_check_mark: |        | The uuid of descriptor                    |
+| read               | :white_check_mark: | :white_check_mark: | :fire: | Retrieves the value of the descriptor     |
+| write              | :white_check_mark: | :white_check_mark: | :fire: | Writes the value of the descriptor        |
+| onValueReceived 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of descriptor value reads & writes |
+| lastValue        ⚡ | :white_check_mark: | :white_check_mark: |        | The most recent value of the descriptor   |
+| lastValueStream 🌀 | :white_check_mark: | :white_check_mark: |        | Stream of onValueReceived + writes        |
 
 ## Debugging
 

--- a/android/src/main/java/com/lib/flutter_blue_plus/ErrorCodes.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/ErrorCodes.java
@@ -1,0 +1,17 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus;
+
+public interface ErrorCodes {
+    String PLATFORM_NOT_SUPPORTED = "platform_not_supported";
+    String OPEN_L2CAP_CHANNEL_FAILED = "open_l2cap_channel_failed";
+    String CLOSE_L2CAP_CHANNEL_FAILED = "close_l2cap_channel_failed";
+    String SOCKET_NOT_OPEN = "no_socket_or_stream_is_open";
+    String INPUT_STREAM_READ_FAILED = "input_stream_read_failed";
+    String OUTPUT_STREAM_WRITE_FAILED = "output_stream_write_failed";
+    String NO_OPEN_L2CAP_CHANNEL_FOUND = "no_open_l2cap_channel_found";
+    String BLUETOOTH_TURNED_OFF = "bluetooth_turned_off";
+    String MESSAGE_ARGUMENTS_NOT_PROVIDED = "message_arguments_not_provided";
+    String NO_PERMISSION = "no_permissions";
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/MarshallingUtil.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/MarshallingUtil.java
@@ -1,0 +1,397 @@
+// Copyright 2023, Charles Weinberger, Paul DeMarco & Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus;
+
+import android.annotation.SuppressLint;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+import android.bluetooth.BluetoothGattService;
+import android.bluetooth.BluetoothProfile;
+import android.bluetooth.le.ScanRecord;
+import android.bluetooth.le.ScanResult;
+import android.os.Build;
+import android.os.ParcelUuid;
+import android.util.SparseArray;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class MarshallingUtil {
+    @SuppressLint("MissingPermission")
+    static HashMap<String, Object> bmScanAdvertisement(BluetoothDevice device, ScanResult result) {
+
+        int min = Integer.MIN_VALUE;
+
+        ScanRecord adv = result.getScanRecord();
+
+        boolean connectable;
+        if (Build.VERSION.SDK_INT >= 26) { // Android 8.0, August 2017
+            connectable = result.isConnectable();
+        } else {
+            // Prior to Android 8.0, it is not possible to get if connectable.
+            // Previously, we used to check `adv.getAdvertiseFlags() & 0x2` but that
+            // returns if the device wants to be *discoverable*, which is not the same thing.
+            connectable = true;
+        }
+
+        String advName = adv != null ? adv.getDeviceName() : null;
+        int txPower = adv != null ? adv.getTxPowerLevel() : min;
+        int appearance = adv != null ? getAppearanceFromScanRecord(adv) : 0;
+        SparseArray<byte[]> manufData = adv != null ? adv.getManufacturerSpecificData() : null;
+        List<ParcelUuid> serviceUuids = adv != null ? adv.getServiceUuids() : null;
+        Map<ParcelUuid, byte[]> serviceData = adv != null ? adv.getServiceData() : null;
+
+        // Manufacturer Specific Data
+        HashMap<Integer, String> manufDataB = new HashMap<Integer, String>();
+        if (manufData != null) {
+            for (int i = 0; i < manufData.size(); i++) {
+                int key = manufData.keyAt(i);
+                byte[] value = manufData.valueAt(i);
+                manufDataB.put(key, bytesToHex(value));
+            }
+        }
+
+        // Service Data
+        HashMap<String, Object> serviceDataB = new HashMap<>();
+        if (serviceData != null) {
+            for (Map.Entry<ParcelUuid, byte[]> entry : serviceData.entrySet()) {
+                ParcelUuid key = entry.getKey();
+                byte[] value = entry.getValue();
+                serviceDataB.put(uuidStr(key.getUuid()), bytesToHex(value));
+            }
+        }
+
+        // Service UUIDs
+        List<String> serviceUuidsB = new ArrayList<String>();
+        if (serviceUuids != null) {
+            for (ParcelUuid s : serviceUuids) {
+                serviceUuidsB.add(uuidStr(s.getUuid()));
+            }
+        }
+
+        // See: BmScanAdvertisement
+        // perf: only add keys if they exists
+        HashMap<String, Object> map = new HashMap<>();
+        if (device.getAddress() != null) {
+            map.put("remote_id", device.getAddress());
+        }
+
+        if (device.getName() != null) {
+            map.put("platform_name", device.getName());
+        }
+        if (connectable) {
+            map.put("connectable", 1);
+        }
+        if (advName != null) {
+            map.put("adv_name", advName);
+        }
+        if (txPower != min) {
+            map.put("tx_power_level", txPower);
+        }
+        if (appearance != 0) {
+            map.put("appearance", appearance);
+        }
+        if (manufData != null) {
+            map.put("manufacturer_data", manufDataB);
+        }
+        if (serviceData != null) {
+            map.put("service_data", serviceDataB);
+        }
+        if (serviceUuids != null) {
+            map.put("service_uuids", serviceUuidsB);
+        }
+        if (result.getRssi() != 0) {
+            map.put("rssi", result.getRssi());
+        }
+
+        return map;
+    }
+
+    // See: BmBluetoothDevice
+    @SuppressLint("MissingPermission")
+    public static HashMap<String, Object> bmBluetoothDevice(BluetoothDevice device) {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("remote_id", device.getAddress());
+        map.put("platform_name", device.getName());
+        return map;
+    }
+
+    static HashMap<String, Object> bmBluetoothService(BluetoothDevice device, BluetoothGattService service, BluetoothGatt gatt) {
+
+        List<Object> characteristics = new ArrayList<Object>();
+        for (BluetoothGattCharacteristic c : service.getCharacteristics()) {
+            characteristics.add(bmBluetoothCharacteristic(device, c, gatt));
+        }
+
+        List<Object> includedServices = new ArrayList<Object>();
+        for (BluetoothGattService included : service.getIncludedServices()) {
+            // service includes itself?
+            if (included.getUuid().equals(service.getUuid())) {
+                continue; // skip, infinite recursion
+            }
+            includedServices.add(bmBluetoothService(device, included, gatt));
+        }
+
+        // See: BmBluetoothService
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("remote_id", device.getAddress());
+        map.put("service_uuid", uuidStr(service.getUuid()));
+        map.put("is_primary", service.getType() == BluetoothGattService.SERVICE_TYPE_PRIMARY ? 1 : 0);
+        map.put("characteristics", characteristics);
+        map.put("included_services", includedServices);
+        return map;
+    }
+
+    static HashMap<String, Object> bmBluetoothCharacteristic(BluetoothDevice device, BluetoothGattCharacteristic characteristic, BluetoothGatt gatt) {
+
+        FlutterBluePlusPlugin.ServicePair pair = getServicePair(gatt, characteristic);
+
+        List<Object> descriptors = new ArrayList<Object>();
+        for (BluetoothGattDescriptor d : characteristic.getDescriptors()) {
+            descriptors.add(bmBluetoothDescriptor(device, d));
+        }
+
+        // See: BmBluetoothCharacteristic
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("remote_id", device.getAddress());
+        map.put("service_uuid", uuidStr(pair.primary));
+        if (pair.secondary != null) {
+            map.put("secondary_service_uuid", uuidStr(pair.secondary));
+        }
+        map.put("characteristic_uuid", uuidStr(characteristic.getUuid()));
+        map.put("descriptors", descriptors);
+        map.put("properties", bmCharacteristicProperties(characteristic.getProperties()));
+        return map;
+    }
+
+    // See: BmBluetoothDescriptor
+    static HashMap<String, Object> bmBluetoothDescriptor(BluetoothDevice device, BluetoothGattDescriptor descriptor) {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("remote_id", device.getAddress());
+        map.put("descriptor_uuid", uuidStr(descriptor.getUuid()));
+        map.put("characteristic_uuid", uuidStr(descriptor.getCharacteristic().getUuid()));
+        map.put("service_uuid", uuidStr(descriptor.getCharacteristic().getService().getUuid()));
+        return map;
+    }
+
+    // See: BmCharacteristicProperties
+    static HashMap<String, Object> bmCharacteristicProperties(int properties) {
+        HashMap<String, Object> props = new HashMap<>();
+        props.put("broadcast", (properties & 1) != 0 ? 1 : 0);
+        props.put("read", (properties & 2) != 0 ? 1 : 0);
+        props.put("write_without_response", (properties & 4) != 0 ? 1 : 0);
+        props.put("write", (properties & 8) != 0 ? 1 : 0);
+        props.put("notify", (properties & 16) != 0 ? 1 : 0);
+        props.put("indicate", (properties & 32) != 0 ? 1 : 0);
+        props.put("authenticated_signed_writes", (properties & 64) != 0 ? 1 : 0);
+        props.put("extended_properties", (properties & 128) != 0 ? 1 : 0);
+        props.put("notify_encryption_required", (properties & 256) != 0 ? 1 : 0);
+        props.put("indicate_encryption_required", (properties & 512) != 0 ? 1 : 0);
+        return props;
+    }
+
+    // See: BmConnectionStateEnum
+    static int bmConnectionStateEnum(int cs) {
+        switch (cs) {
+            case BluetoothProfile.STATE_DISCONNECTED:
+                return 0;
+            case BluetoothProfile.STATE_CONNECTED:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+
+    // See: BmAdapterStateEnum
+    static int bmAdapterStateEnum(int as) {
+        switch (as) {
+            case BluetoothAdapter.STATE_OFF:
+                return 6;
+            case BluetoothAdapter.STATE_ON:
+                return 4;
+            case BluetoothAdapter.STATE_TURNING_OFF:
+                return 5;
+            case BluetoothAdapter.STATE_TURNING_ON:
+                return 3;
+            default:
+                return 0;
+        }
+    }
+
+    // See: BmBondStateEnum
+    static int bmBondStateEnum(int bs) {
+        switch (bs) {
+            case BluetoothDevice.BOND_NONE:
+                return 0;
+            case BluetoothDevice.BOND_BONDING:
+                return 1;
+            case BluetoothDevice.BOND_BONDED:
+                return 2;
+            default:
+                return 0;
+        }
+    }
+
+    // See: BmConnectionPriority
+    static int bmConnectionPriorityParse(int value) {
+        switch (value) {
+            case 0:
+                return BluetoothGatt.CONNECTION_PRIORITY_BALANCED;
+            case 1:
+                return BluetoothGatt.CONNECTION_PRIORITY_HIGH;
+            case 2:
+                return BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER;
+            default:
+                return BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER;
+        }
+    }
+
+    public static byte[] hexToBytes(String s) {
+        if (s == null) {
+            return new byte[0];
+        }
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                    + Character.digit(s.charAt(i + 1), 16));
+        }
+
+        return data;
+    }
+
+    public static String bytesToHex(byte[] bytes) {
+        if (bytes == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    static FlutterBluePlusPlugin.ServicePair getServicePair(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
+
+        FlutterBluePlusPlugin.ServicePair result = new FlutterBluePlusPlugin.ServicePair();
+
+        BluetoothGattService service = characteristic.getService();
+
+        // is this a primary service?
+        if (service.getType() == BluetoothGattService.SERVICE_TYPE_PRIMARY) {
+            result.primary = service.getUuid();
+            return result;
+        }
+
+        // Otherwise, iterate all services until we find the primary service
+        for (BluetoothGattService primary : gatt.getServices()) {
+            for (BluetoothGattService secondary : primary.getIncludedServices()) {
+                if (secondary.getUuid().equals(service.getUuid())) {
+                    result.primary = primary.getUuid();
+                    result.secondary = secondary.getUuid();
+                    return result;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    static String uuid128(Object uuid) {
+        if (!(uuid instanceof UUID) && !(uuid instanceof String)) {
+            throw new IllegalArgumentException("input must be UUID or String");
+        }
+
+        String s = uuid.toString();
+
+        if (s.length() == 4) {
+            // 16-bit uuid
+            return String.format("0000%s-0000-1000-8000-00805f9b34fb", s).toLowerCase();
+        } else if (s.length() == 8) {
+            // 32-bit uuid
+            return String.format("%s-0000-1000-8000-00805f9b34fb", s).toLowerCase();
+        } else {
+            // 128-bit uuid
+            return s.toLowerCase();
+        }
+    }
+
+    // returns shortest representation
+    static String uuidStr(Object uuid) {
+        String s = uuid128(uuid);
+        boolean starts = s.startsWith("0000");
+        boolean ends = s.endsWith("-0000-1000-8000-00805f9b34fb");
+        if (starts && ends) {
+            // 16-bit
+            return s.substring(4, 8);
+        } else if (ends) {
+            // 32-bit
+            return s.substring(0, 8);
+        } else {
+            // 128-bit
+            return s;
+        }
+    }
+
+    static int getAppearanceFromScanRecord(ScanRecord adv) {
+
+        if (Build.VERSION.SDK_INT >= 33) { // Android 13 (August 2022)
+            Map<Integer, byte[]> map = adv.getAdvertisingDataMap();
+            if (map.containsKey(ScanRecord.DATA_TYPE_APPEARANCE)) {
+                byte[] bytes = map.get(ScanRecord.DATA_TYPE_APPEARANCE);
+                if (bytes.length == 2) {
+                    int loByte = bytes[0] & 0xFF;
+                    int hiByte = bytes[1] & 0xFF;
+                    return hiByte * 256 + loByte;
+                }
+            }
+            return 0;
+        }
+
+        // For API Level 21+
+        byte[] bytes = adv.getBytes();
+
+        int n = 0;
+
+        while (n < bytes.length) {
+
+            int fieldLen = bytes[n];
+
+            // no more or malformed data
+            if (fieldLen <= 0) {
+                break;
+            }
+
+            // end of packet
+            if (fieldLen + n > bytes.length - 1) {
+                break;
+            }
+
+            int dataType = bytes[n + 1];
+
+            // no more data
+            if (dataType == 0) {
+                break;
+            }
+
+            // appearance type byte
+            if (dataType == 0x19 && fieldLen == 3) {
+                int loByte = bytes[n + 2] & 0xFF;
+                int hiByte = bytes[n + 3] & 0xFF;
+                return hiByte * 256 + loByte;
+            }
+
+            n += fieldLen + 1;
+        }
+
+        return 0;
+    }
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/L2CapAttributeNames.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/L2CapAttributeNames.java
@@ -1,0 +1,14 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap;
+
+public interface L2CapAttributeNames {
+    String KEY_BLUETOOTH_DEVICE = "bluetoothDevice";
+    String KEY_PSM = "psm";
+    String KEY_SECURE = "secure";
+    String KEY_REMOTE_ID = "remote_id";
+    String KEY_BYTES_READ = "bytes_read";
+    String KEY_VALUE = "value";
+
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/L2CapChannelManager.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/L2CapChannelManager.java
@@ -1,0 +1,199 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothServerSocket;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.lib.flutter_blue_plus.ErrorCodes;
+import com.lib.flutter_blue_plus.l2cap.channel.L2CapChannel;
+import com.lib.flutter_blue_plus.l2cap.channel.L2CapClientChannel;
+import com.lib.flutter_blue_plus.l2cap.info.ClientSocketInfo;
+import com.lib.flutter_blue_plus.l2cap.info.L2CapInfo;
+import com.lib.flutter_blue_plus.l2cap.info.ServerSocketInfo;
+import com.lib.flutter_blue_plus.l2cap.messages.CloseL2CapChannelRequest;
+import com.lib.flutter_blue_plus.l2cap.messages.CloseL2CapServer;
+import com.lib.flutter_blue_plus.l2cap.messages.ListenL2CapChannelRequest;
+import com.lib.flutter_blue_plus.l2cap.messages.ListenL2CapChannelResponse;
+import com.lib.flutter_blue_plus.l2cap.messages.OpenL2CapChannelRequest;
+import com.lib.flutter_blue_plus.l2cap.messages.ReadL2CapChannelRequest;
+import com.lib.flutter_blue_plus.l2cap.messages.WriteL2CapChannelRequest;
+import com.lib.flutter_blue_plus.log.LogLevel;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import io.flutter.plugin.common.MethodChannel.Result;
+
+@TargetApi(Build.VERSION_CODES.Q)
+public class L2CapChannelManager {
+    private final BluetoothAdapter adapter;
+    private final DeviceConnected deviceConnectedCallback;
+    private final List<L2CapInfo> openL2CapChannelInfos = Collections.synchronizedList(new LinkedList<>());
+
+    public L2CapChannelManager(@NonNull final BluetoothAdapter adapter, @NonNull final DeviceConnected deviceConnectedCallback) {
+        this.adapter = adapter;
+        this.deviceConnectedCallback = deviceConnectedCallback;
+    }
+
+    @SuppressLint("MissingPermission")
+    public synchronized void listenUsingL2capChannel(ListenL2CapChannelRequest request, final Result resultCallback) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            firePlatformNotSupportedError(resultCallback);
+            return;
+        }
+        if (!adapter.isEnabled()) {
+            LogLevel.DEBUG.log("Bluetooth is disabled. Please enable first.");
+            resultCallback.error(ErrorCodes.BLUETOOTH_TURNED_OFF, "Bluetooth is turned off.", null);
+            return;
+        }
+
+        try {
+            final BluetoothServerSocket serverSocket;
+            if (request.secure) {
+                serverSocket = adapter.listenUsingL2capChannel();
+            } else {
+                serverSocket = adapter.listenUsingInsecureL2capChannel();
+            }
+            final ServerSocketInfo socketInfo = new ServerSocketInfo(serverSocket, deviceConnectedCallback);
+            openL2CapChannelInfos.add(socketInfo);
+            final int psm = serverSocket.getPsm();
+            socketInfo.acceptConnections();
+
+            final ListenL2CapChannelResponse response = new ListenL2CapChannelResponse(psm);
+            resultCallback.success(response.marshal());
+
+        } catch (IOException e) {
+            LogLevel.ERROR.log(e.getMessage(), e);
+            resultCallback.error(ErrorCodes.OPEN_L2CAP_CHANNEL_FAILED, e.getMessage(), e);
+        }
+
+    }
+
+    public synchronized void connectToL2CapChannel(final OpenL2CapChannelRequest request, final Result resultCallback) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            firePlatformNotSupportedError(resultCallback);
+            return;
+        }
+        final String deviceId = request.remoteId;
+        final BluetoothDevice device = adapter.getRemoteDevice(deviceId);
+        final int psm = request.psm;
+        final boolean secure = request.secure;
+
+        L2CapInfo l2CapInfo = findInfo(psm);
+        if (l2CapInfo == null) {
+            LogLevel.DEBUG.log("L2CAP Channel with for device " + device.getAddress() + " / psm " + psm + " not open yet. Create channel.");
+            l2CapInfo = new ClientSocketInfo(new L2CapClientChannel(device, psm));
+            openL2CapChannelInfos.add(l2CapInfo);
+        }
+        final L2CapClientChannel l2CapChannel = ((L2CapClientChannel) l2CapInfo.getL2CapChannel(device));
+        l2CapChannel.connectToL2CapChannel(secure, resultCallback);
+    }
+
+    public void read(final ReadL2CapChannelRequest request, final Result resultCallback) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            firePlatformNotSupportedError(resultCallback);
+            return;
+        }
+        final String deviceId = request.remoteId;
+        final BluetoothDevice device = adapter.getRemoteDevice(deviceId);
+        final int psm = request.psm;
+        final L2CapChannel channel = findChannel(psm, device);
+        if (channel == null) {
+            resultCallback.error(ErrorCodes.NO_OPEN_L2CAP_CHANNEL_FOUND, "No open channel found for device " + device.getAddress() + " / psm " + psm, null);
+            return;
+        }
+        channel.read(request, resultCallback);
+    }
+
+    public void write(final WriteL2CapChannelRequest request, final Result resultCallback) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            firePlatformNotSupportedError(resultCallback);
+            return;
+        }
+        final String deviceId = request.remoteId;
+        final BluetoothDevice device = adapter.getRemoteDevice(deviceId);
+        final int psm = request.psm;
+        final L2CapChannel channel = findChannel(psm, device);
+        if (channel == null) {
+            resultCallback.error(ErrorCodes.NO_OPEN_L2CAP_CHANNEL_FOUND, "No open channel found for device " + device.getAddress() + " / psm " + psm, null);
+            return;
+        }
+        channel.write(request, resultCallback);
+    }
+
+    public synchronized void closeChannel(final CloseL2CapChannelRequest request, final Result resultCallback) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            firePlatformNotSupportedError(resultCallback);
+            return;
+        }
+        final String deviceId = request.remoteId;
+        final BluetoothDevice device = adapter.getRemoteDevice(deviceId);
+        final int psm = request.psm;
+        final L2CapInfo channelInfo = findInfo(psm);
+        if (channelInfo != null) {
+            try {
+                channelInfo.close(device);
+            } catch (IOException e) {
+                LogLevel.ERROR.log(e.getMessage(), e);
+                resultCallback.error(ErrorCodes.CLOSE_L2CAP_CHANNEL_FAILED, "Can't close channel with psm " + psm, null);
+            }
+            if (channelInfo.getType() == L2CapInfo.Type.CLIENT) {
+                openL2CapChannelInfos.remove(channelInfo);
+            }
+        } else {
+            LogLevel.DEBUG.log("No channel found which is matching device " + device.getAddress() + " / psm " + psm);
+        }
+        resultCallback.success(null);
+    }
+
+    public synchronized void closeServerSocket(CloseL2CapServer options, final Result resultCallback) {
+        final int psm = options.psm;
+        final L2CapInfo channelInfo = findInfo(psm);
+        if (channelInfo != null && channelInfo.getType() == L2CapInfo.Type.SERVER) {
+            ((ServerSocketInfo) channelInfo).closeSocket();
+            openL2CapChannelInfos.remove(channelInfo);
+        } else {
+            LogLevel.DEBUG.log("No server socket found with psm " + psm);
+        }
+        resultCallback.success(null);
+    }
+
+    private void firePlatformNotSupportedError(Result resultCallback) {
+        resultCallback.error(ErrorCodes.PLATFORM_NOT_SUPPORTED, "The device is running an older Android version. Minimum version is Android Q.", null);
+    }
+
+    @Nullable
+    private L2CapInfo findInfo(final int psm) {
+        for (L2CapInfo channelInfo : openL2CapChannelInfos) {
+            if (psm == channelInfo.getPsm()) {
+                return channelInfo;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private L2CapChannel findChannel(final int psm, final BluetoothDevice remoteDevice) {
+        final L2CapInfo l2CapInfo = findInfo(psm);
+        if (l2CapInfo == null) {
+            return null;
+        }
+        return l2CapInfo.getL2CapChannel(remoteDevice);
+    }
+
+
+    public interface DeviceConnected {
+        void deviceConnected(BluetoothDevice remoteDevice, int psm);
+    }
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/L2CapMethodNames.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/L2CapMethodNames.java
@@ -1,0 +1,15 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap;
+
+public interface L2CapMethodNames {
+
+    String CONNECT_TO_L2CAP_CHANNEL = "connectToL2CapChannel";
+    String CLOSE_L2CAP_CHANNEL = "closeL2CapChannel";
+    String READ_L2CAP_CHANNEL = "readL2CapChannel";
+    String WRITE_L2CAP_CHANNEL = "writeL2CapChannel";
+    String DEVICE_CONNECTED = "deviceConnectedToL2CapChannel";
+    String LISTEN_L2CAP_CHANNEL = "listenL2CapChannel";
+    String CLOSE_L2CAP_SERVER = "closeL2CapServer";
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/channel/L2CapChannel.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/channel/L2CapChannel.java
@@ -1,0 +1,95 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.channel;
+
+import android.bluetooth.BluetoothSocket;
+
+import com.lib.flutter_blue_plus.ErrorCodes;
+import com.lib.flutter_blue_plus.l2cap.messages.ReadL2CapChannelRequest;
+import com.lib.flutter_blue_plus.l2cap.messages.ReadL2CapChannelResponse;
+import com.lib.flutter_blue_plus.l2cap.messages.WriteL2CapChannelRequest;
+import com.lib.flutter_blue_plus.log.LogLevel;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import io.flutter.plugin.common.MethodChannel.Result;
+
+public abstract class L2CapChannel {
+
+    protected static final int DEFAULT_READ_BUFFER_SIZE = 50;
+    protected final byte[] readBuffer;
+    protected BluetoothSocket socket;
+    protected OutputStream outputStream;
+    protected InputStream inputStream;
+
+    public L2CapChannel(final int readBufferSize) {
+        readBuffer = new byte[readBufferSize];
+    }
+
+    public BluetoothSocket getSocket() {
+        return socket;
+    }
+
+    public void read(final ReadL2CapChannelRequest request, final Result resultCallback) {
+        if (inputStream == null || socket == null || !socket.isConnected()) {
+            resultCallback.error(ErrorCodes.SOCKET_NOT_OPEN, "The bluetooth socket or the input stream is not open.", null);
+            return;
+        }
+        try {
+            final int bytesRead = inputStream.read(readBuffer);
+            final ReadL2CapChannelResponse response = new ReadL2CapChannelResponse(request.remoteId, request.psm, bytesRead, readBuffer);
+            resultCallback.success(response.marshal());
+        } catch (IOException e) {
+            LogLevel.ERROR.log(e.getMessage(), e);
+            resultCallback.error(ErrorCodes.INPUT_STREAM_READ_FAILED, e.getMessage(), e);
+        }
+    }
+
+    public void write(final WriteL2CapChannelRequest request, final Result resultCallback) {
+        if (outputStream == null || socket == null || !socket.isConnected()) {
+            resultCallback.error(ErrorCodes.SOCKET_NOT_OPEN, "The bluetooth socket or the output stream is not open.", null);
+            return;
+        }
+        final byte[] data = request.value;
+        try {
+            outputStream.write(data);
+            resultCallback.success(null);
+        } catch (IOException e) {
+            LogLevel.ERROR.log(e.getMessage(), e);
+            resultCallback.error(ErrorCodes.OUTPUT_STREAM_WRITE_FAILED, e.getMessage(), e);
+        }
+    }
+
+    public synchronized void close() {
+        if (outputStream != null) {
+            try {
+                outputStream.close();
+            } catch (IOException e) {
+                LogLevel.ERROR.log(e.getMessage(), e);
+            } finally {
+                outputStream = null;
+            }
+        }
+        if (inputStream != null) {
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                LogLevel.ERROR.log(e.getMessage(), e);
+            } finally {
+                inputStream = null;
+            }
+        }
+        if (socket != null) {
+            try {
+                socket.close();
+            } catch (IOException e) {
+                LogLevel.ERROR.log(e.getMessage(), e);
+            } finally {
+                socket = null;
+            }
+        }
+    }
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/channel/L2CapClientChannel.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/channel/L2CapClientChannel.java
@@ -1,0 +1,58 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.channel;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.bluetooth.BluetoothDevice;
+import android.os.Build;
+
+import com.lib.flutter_blue_plus.ErrorCodes;
+import com.lib.flutter_blue_plus.log.LogLevel;
+
+import java.io.IOException;
+
+import io.flutter.plugin.common.MethodChannel.Result;
+
+public class L2CapClientChannel extends L2CapChannel {
+    private final BluetoothDevice device;
+    private final int psm;
+
+    public L2CapClientChannel(final BluetoothDevice device, final int psm) {
+        this(device, psm, DEFAULT_READ_BUFFER_SIZE);
+    }
+
+    public L2CapClientChannel(final BluetoothDevice device, final int psm, final int readBufferSize) {
+        super(readBufferSize);
+        this.psm = psm;
+        this.device = device;
+    }
+
+    @SuppressLint("MissingPermission")
+    @TargetApi(Build.VERSION_CODES.Q)
+    public synchronized void connectToL2CapChannel(final boolean secure, final Result resultCallback) {
+        try {
+            if (secure) {
+                socket = device.createL2capChannel(psm);
+            } else {
+                socket = device.createInsecureL2capChannel(psm);
+            }
+            socket.connect();
+            inputStream = socket.getInputStream();
+            outputStream = socket.getOutputStream();
+            resultCallback.success(null);
+        } catch (IOException e) {
+            LogLevel.ERROR.log(e.getMessage(), e);
+            resultCallback.error(ErrorCodes.OPEN_L2CAP_CHANNEL_FAILED, e.getMessage(), e);
+        }
+    }
+
+    public BluetoothDevice getDevice() {
+        return device;
+    }
+
+    public int getPsm() {
+        return psm;
+    }
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/channel/L2CapServerChannel.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/channel/L2CapServerChannel.java
@@ -1,0 +1,32 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.channel;
+
+import android.annotation.TargetApi;
+import android.bluetooth.BluetoothSocket;
+import android.os.Build;
+
+import com.lib.flutter_blue_plus.log.LogLevel;
+
+import java.io.IOException;
+
+public class L2CapServerChannel extends L2CapChannel {
+
+
+    public L2CapServerChannel(final BluetoothSocket socket) {
+        this(socket, DEFAULT_READ_BUFFER_SIZE);
+    }
+
+    public L2CapServerChannel(final BluetoothSocket socket, final int readBufferSize) {
+        super(readBufferSize);
+        this.socket = socket;
+    }
+
+    @TargetApi(Build.VERSION_CODES.Q)
+    public synchronized void openStreams() throws IOException {
+        LogLevel.DEBUG.log("Opening streams");
+        inputStream = socket.getInputStream();
+        outputStream = socket.getOutputStream();
+    }
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/info/ClientSocketInfo.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/info/ClientSocketInfo.java
@@ -1,0 +1,43 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.info;
+
+import android.bluetooth.BluetoothDevice;
+
+import androidx.annotation.NonNull;
+
+import com.lib.flutter_blue_plus.l2cap.channel.L2CapChannel;
+import com.lib.flutter_blue_plus.l2cap.channel.L2CapClientChannel;
+
+public class ClientSocketInfo implements L2CapInfo {
+
+    final L2CapClientChannel l2capChannel;
+
+    public ClientSocketInfo(@NonNull final L2CapClientChannel l2capChannel) {
+        this.l2capChannel = l2capChannel;
+    }
+
+    @Override
+    public Type getType() {
+        return Type.CLIENT;
+    }
+
+    @Override
+    public int getPsm() {
+        return l2capChannel.getPsm();
+    }
+
+    @Override
+    public L2CapChannel getL2CapChannel(BluetoothDevice remoteDevice) {
+        if (remoteDevice.getAddress().equals(l2capChannel.getDevice().getAddress())) {
+            return l2capChannel;
+        }
+        return null;
+    }
+
+    @Override
+    public void close(final BluetoothDevice device) {
+        l2capChannel.close();
+    }
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/info/L2CapInfo.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/info/L2CapInfo.java
@@ -1,0 +1,26 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.info;
+
+import android.bluetooth.BluetoothDevice;
+
+import com.lib.flutter_blue_plus.l2cap.channel.L2CapChannel;
+
+import java.io.IOException;
+
+public interface L2CapInfo {
+
+    Type getType();
+
+    int getPsm();
+
+    L2CapChannel getL2CapChannel(final BluetoothDevice remoteDevice);
+
+    void close(final BluetoothDevice device) throws IOException;
+
+    enum Type {
+        CLIENT,
+        SERVER,
+    }
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/info/ServerSocketInfo.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/info/ServerSocketInfo.java
@@ -1,0 +1,110 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.info;
+
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothServerSocket;
+import android.bluetooth.BluetoothSocket;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.annotation.RequiresApi;
+
+import com.lib.flutter_blue_plus.l2cap.L2CapChannelManager;
+import com.lib.flutter_blue_plus.l2cap.channel.L2CapServerChannel;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+@RequiresApi(api = Build.VERSION_CODES.Q)
+public class ServerSocketInfo implements L2CapInfo {
+
+    private static final String TAG = ServerSocketInfo.class.getSimpleName();
+    final BluetoothServerSocket serverSocket;
+    private final List<L2CapServerChannel> openChannels;
+    private final L2CapChannelManager.DeviceConnected deviceConnectedCallback;
+    private boolean isAcceptingConnections;
+
+    public ServerSocketInfo(BluetoothServerSocket serverSocket, final L2CapChannelManager.DeviceConnected deviceConnectedCallback) {
+        this.serverSocket = serverSocket;
+        this.deviceConnectedCallback = deviceConnectedCallback;
+        openChannels = Collections.synchronizedList(new LinkedList<>());
+        isAcceptingConnections = false;
+    }
+
+    @Override
+    public Type getType() {
+        return Type.SERVER;
+    }
+
+    @Override
+    public int getPsm() {
+        return serverSocket.getPsm();
+    }
+
+    void addConnection(final L2CapServerChannel channel) {
+        openChannels.add(channel);
+    }
+
+    @Override
+    public L2CapServerChannel getL2CapChannel(final BluetoothDevice remoteDevice) {
+        for (L2CapServerChannel openChannel :
+                openChannels) {
+            if (remoteDevice.getAddress().equals(openChannel.getSocket().getRemoteDevice().getAddress())) {
+                return openChannel;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void close(final BluetoothDevice device) {
+        final L2CapServerChannel channelToDelete = getL2CapChannel(device);
+        if (channelToDelete == null) {
+            return;
+        }
+        channelToDelete.close();
+        openChannels.remove(channelToDelete);
+    }
+
+    public void acceptConnections() {
+        isAcceptingConnections = true;
+        new Thread(() -> {
+            while (isAcceptingConnections) {
+                try {
+                    final BluetoothSocket socket = serverSocket.accept();
+                    if (!isAcceptingConnections) {
+                        Log.d(TAG, "Stopping server socket. Close thread.");
+                        break;
+                    }
+                    final L2CapServerChannel l2capChannel = new L2CapServerChannel(socket);
+                    l2capChannel.openStreams();
+                    addConnection(l2capChannel);
+                    deviceConnectedCallback.deviceConnected(socket.getRemoteDevice(), getPsm());
+                } catch (IOException e) {
+                    if (isAcceptingConnections) {
+                        Log.e(TAG, "Accepting incoming connection failed.", e);
+                    }
+                }
+            }
+        }).start();
+    }
+
+
+    public void closeSocket() {
+        for (L2CapServerChannel openChannel :
+                openChannels) {
+            openChannel.close();
+        }
+        openChannels.clear();
+        isAcceptingConnections = false;
+        try {
+            serverSocket.close();
+        } catch (IOException e) {
+            Log.e(TAG, "Error while closing server socket.", e);
+        }
+    }
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/CloseL2CapChannelRequest.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/CloseL2CapChannelRequest.java
@@ -1,0 +1,27 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.messages;
+
+import com.lib.flutter_blue_plus.l2cap.L2CapAttributeNames;
+
+import java.util.Map;
+
+public class CloseL2CapChannelRequest {
+    public final String remoteId;
+    public final int psm;
+
+
+    public CloseL2CapChannelRequest(String remoteId, int psm) {
+        this.remoteId = remoteId;
+        this.psm = psm;
+    }
+
+    public static CloseL2CapChannelRequest unmarshal(final Map<String, Object> data) {
+        final String remoteId = (String) data.get(L2CapAttributeNames.KEY_REMOTE_ID);
+        final int psm = (int) data.get(L2CapAttributeNames.KEY_PSM);
+        return new CloseL2CapChannelRequest(remoteId, psm);
+    }
+
+
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/CloseL2CapServer.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/CloseL2CapServer.java
@@ -1,0 +1,22 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.messages;
+
+import com.lib.flutter_blue_plus.l2cap.L2CapAttributeNames;
+
+import java.util.Map;
+
+public class CloseL2CapServer {
+    public final int psm;
+
+    public CloseL2CapServer(int psm) {
+        this.psm = psm;
+    }
+
+    public static CloseL2CapServer unmarshal(final Map<String, Object> data) {
+        final int psm = (int) data.get(L2CapAttributeNames.KEY_PSM);
+        return new CloseL2CapServer(psm);
+    }
+
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/DeviceConnectedToL2CapChannel.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/DeviceConnectedToL2CapChannel.java
@@ -1,0 +1,29 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.messages;
+
+import android.bluetooth.BluetoothDevice;
+
+import com.lib.flutter_blue_plus.MarshallingUtil;
+import com.lib.flutter_blue_plus.l2cap.L2CapAttributeNames;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DeviceConnectedToL2CapChannel {
+    public final BluetoothDevice device;
+    public final int psm;
+
+    public DeviceConnectedToL2CapChannel(BluetoothDevice device, int psm) {
+        this.device = device;
+        this.psm = psm;
+    }
+
+    public Map<String, Object> marshal() {
+        final Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(L2CapAttributeNames.KEY_PSM, psm);
+        dataMap.put(L2CapAttributeNames.KEY_BLUETOOTH_DEVICE, MarshallingUtil.bmBluetoothDevice(device));
+        return dataMap;
+    }
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/ListenL2CapChannelRequest.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/ListenL2CapChannelRequest.java
@@ -1,0 +1,22 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.messages;
+
+import com.lib.flutter_blue_plus.l2cap.L2CapAttributeNames;
+
+import java.util.Map;
+
+public class ListenL2CapChannelRequest {
+    public final boolean secure;
+
+    public ListenL2CapChannelRequest(boolean secure) {
+        this.secure = secure;
+    }
+
+    public static ListenL2CapChannelRequest unmarshal(final Map<String, Object> data) {
+        final boolean secure = (boolean) data.get(L2CapAttributeNames.KEY_SECURE);
+        return new ListenL2CapChannelRequest(secure);
+    }
+
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/ListenL2CapChannelResponse.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/ListenL2CapChannelResponse.java
@@ -1,0 +1,23 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.messages;
+
+import com.lib.flutter_blue_plus.l2cap.L2CapAttributeNames;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ListenL2CapChannelResponse {
+    public final int psm;
+
+    public ListenL2CapChannelResponse(final int psm) {
+        this.psm = psm;
+    }
+
+    public Map<String, Object> marshal() {
+        final Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(L2CapAttributeNames.KEY_PSM, psm);
+        return dataMap;
+    }
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/OpenL2CapChannelRequest.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/OpenL2CapChannelRequest.java
@@ -1,0 +1,29 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.messages;
+
+import com.lib.flutter_blue_plus.l2cap.L2CapAttributeNames;
+
+import java.util.Map;
+
+public class OpenL2CapChannelRequest {
+    public final String remoteId;
+    public final int psm;
+    public final boolean secure;
+
+    public OpenL2CapChannelRequest(String remoteId, int psm, boolean secure) {
+        this.remoteId = remoteId;
+        this.psm = psm;
+        this.secure = secure;
+    }
+
+    public static OpenL2CapChannelRequest unmarshal(final Map<String, Object> data) {
+        final String remoteId = (String) data.get(L2CapAttributeNames.KEY_REMOTE_ID);
+        final int psm = (int) data.get(L2CapAttributeNames.KEY_PSM);
+        final boolean secure = (boolean) data.get(L2CapAttributeNames.KEY_SECURE);
+        return new OpenL2CapChannelRequest(remoteId, psm, secure);
+    }
+
+
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/ReadL2CapChannelRequest.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/ReadL2CapChannelRequest.java
@@ -1,0 +1,26 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.messages;
+
+import com.lib.flutter_blue_plus.l2cap.L2CapAttributeNames;
+
+import java.util.Map;
+
+public class ReadL2CapChannelRequest {
+    public final String remoteId;
+    public final int psm;
+
+    public ReadL2CapChannelRequest(String remoteId, int psm) {
+        this.remoteId = remoteId;
+        this.psm = psm;
+    }
+
+
+    public static ReadL2CapChannelRequest unmarshal(final Map<String, Object> data) {
+        final int psm = (int) data.get(L2CapAttributeNames.KEY_PSM);
+        final String remoteId = (String) data.get(L2CapAttributeNames.KEY_REMOTE_ID);
+        return new ReadL2CapChannelRequest(remoteId, psm);
+    }
+
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/ReadL2CapChannelResponse.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/ReadL2CapChannelResponse.java
@@ -1,0 +1,33 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.messages;
+
+import com.lib.flutter_blue_plus.MarshallingUtil;
+import com.lib.flutter_blue_plus.l2cap.L2CapAttributeNames;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ReadL2CapChannelResponse {
+    public final String remoteId;
+    public final int psm;
+    public final int bytesRead;
+    public final byte[] value;
+
+    public ReadL2CapChannelResponse(String remoteId, int psm, int bytesRead, byte[] value) {
+        this.remoteId = remoteId;
+        this.psm = psm;
+        this.bytesRead = bytesRead;
+        this.value = value;
+    }
+
+    public Map<String, Object> marshal() {
+        final Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(L2CapAttributeNames.KEY_REMOTE_ID, remoteId);
+        dataMap.put(L2CapAttributeNames.KEY_PSM, psm);
+        dataMap.put(L2CapAttributeNames.KEY_BYTES_READ, bytesRead);
+        dataMap.put(L2CapAttributeNames.KEY_VALUE, MarshallingUtil.bytesToHex(value));
+        return dataMap;
+    }
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/WriteL2CapChannelRequest.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/l2cap/messages/WriteL2CapChannelRequest.java
@@ -1,0 +1,29 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.l2cap.messages;
+
+import com.lib.flutter_blue_plus.MarshallingUtil;
+import com.lib.flutter_blue_plus.l2cap.L2CapAttributeNames;
+
+import java.util.Map;
+
+public class WriteL2CapChannelRequest {
+    public final String remoteId;
+    public final int psm;
+    public final byte[] value;
+
+    public WriteL2CapChannelRequest(String remoteId, int psm, byte[] value) {
+        this.remoteId = remoteId;
+        this.psm = psm;
+        this.value = value;
+    }
+
+    public static WriteL2CapChannelRequest unmarshal(final Map<String, Object> data) {
+        final int psm = (int) data.get(L2CapAttributeNames.KEY_PSM);
+        final String remoteId = (String) data.get(L2CapAttributeNames.KEY_REMOTE_ID);
+        final String valueAsString = (String) data.get(L2CapAttributeNames.KEY_VALUE);
+        return new WriteL2CapChannelRequest(remoteId, psm, MarshallingUtil.hexToBytes(valueAsString));
+    }
+
+}

--- a/android/src/main/java/com/lib/flutter_blue_plus/log/LogLevel.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/log/LogLevel.java
@@ -1,0 +1,45 @@
+// Copyright 2024, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+package com.lib.flutter_blue_plus.log;
+
+import io.flutter.Log;
+
+public enum LogLevel {
+    NONE((tag, message, throwable) -> {
+        // Do nothing
+    }),    // 0
+    ERROR(Log::e),   // 1
+    WARNING(Log::w), // 2
+    INFO(Log::i),    // 3
+    DEBUG(Log::d),   // 4
+    VERBOSE(Log::v); // 5
+
+    private static final String TAG = "[FBP-Android]";
+    private static LogLevel LOG_LEVEL = LogLevel.DEBUG;
+    private final LogImplementation logImplementation;
+
+    LogLevel(final LogImplementation logImplementation) {
+        this.logImplementation = logImplementation;
+    }
+
+    public static void setLogLevel(final LogLevel logLevel) {
+        LOG_LEVEL = logLevel;
+    }
+
+    public void log(final String message) {
+        log(message, null);
+    }
+
+    public void log(final String message, final Throwable throwable) {
+        if (ordinal() <= LOG_LEVEL.ordinal()) {
+            logImplementation.log(TAG, String.format("[FBP] %s", message), throwable);
+        }
+    }
+
+    private interface LogImplementation {
+        void log(final String tag, final String message, final Throwable throwable);
+    }
+
+}
+

--- a/android/src/main/java/com/lib/flutter_blue_plus/permission/PermissionUtil.java
+++ b/android/src/main/java/com/lib/flutter_blue_plus/permission/PermissionUtil.java
@@ -1,0 +1,18 @@
+package com.lib.flutter_blue_plus.permission;
+
+import android.Manifest;
+import android.os.Build;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class PermissionUtil {
+
+    public static List<String> permissionForBleConnection() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return Collections.singletonList(Manifest.permission.BLUETOOTH_CONNECT);
+        }
+        return Collections.emptyList();
+    }
+}

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/lib/extension.dart
+++ b/example/lib/extension.dart
@@ -1,0 +1,15 @@
+// Copyright 2023, Christopher Schott
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:convert/convert.dart';
+
+extension BytesToHexString on List<int> {
+  String bytesToHexString() {
+    if (isEmpty) {
+      return '';
+    } else {
+      return hex.encode(this);
+    }
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
-
 import 'screens/bluetooth_off_screen.dart';
 import 'screens/scan_screen.dart';
 

--- a/example/lib/widgets/l2cap_button.dart
+++ b/example/lib/widgets/l2cap_button.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+class L2CapButton extends StatefulWidget {
+  const L2CapButton({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() {
+    return _L2CapButtonState();
+  }
+}
+
+class _L2CapButtonState extends State<L2CapButton> {
+  bool l2CapListening = false;
+  int psm = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: () => _handleButtonClick(context),
+      icon: const Icon(Icons.bluetooth_audio_rounded),
+    );
+  }
+
+  void _handleButtonClick(BuildContext context) async {
+    if (l2CapListening) {
+      await FlutterBluePlus.closeL2CapServer(psm: psm);
+      setState(() {
+        l2CapListening = false;
+      });
+    } else {
+      final int newPsm = await FlutterBluePlus.listenL2CapChannel(secure: true);
+      final snackBar = SnackBar(
+        content: Text('NEW PSM IS: $newPsm'),
+      );
+      setState(() {
+        psm = newPsm;
+        l2CapListening = true;
+      });
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ScaffoldMessenger.of(context).showSnackBar(snackBar);
+      });
+    }
+  }
+}

--- a/example/lib/widgets/send_data_dialog.dart
+++ b/example/lib/widgets/send_data_dialog.dart
@@ -1,0 +1,67 @@
+import 'package:convert/convert.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+class SendDataDialog extends StatefulWidget {
+  final L2CapChannelConnected _connection;
+
+  const SendDataDialog({Key? key, required L2CapChannelConnected connection})
+      : _connection = connection,
+        super(key: key);
+
+  @override
+  State<SendDataDialog> createState() => _SendDataDialogState();
+}
+
+class _SendDataDialogState extends State<SendDataDialog> {
+  late TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+  }
+
+  List<int> _hexStringToIntList(String str) {
+    return hex.decode(str.replaceAll(' ', ''));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hexReg = RegExp(r'^(?:[\dA-Fa-f]{2} ){0,31}[\dA-Fa-f]{2}$');
+
+    return AlertDialog(
+      title: const Text("Send data"),
+      content: TextField(
+        controller: _controller,
+        decoration: InputDecoration(
+            hintText: 'Enter data in hex',
+            errorText: hexReg.hasMatch(_controller.text)
+                ? null
+                : 'Please enter data in hex!'),
+        onChanged: (value) {
+          setState(() {});
+        },
+      ),
+      actions: [
+        TextButton(
+          onPressed: hexReg.hasMatch(_controller.text)
+              ? () {
+                  widget._connection.device.writeL2CapChannel(
+                    psm: widget._connection.psm,
+                    bytesToSend: _hexStringToIntList(_controller.text),
+                  );
+                }
+              : null,
+          child: const Text("Ok"),
+        ),
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text("Cancel"),
+        ),
+      ],
+    );
+  }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: flutter_blue_plus_example
 description: Demonstrates how to use the flutter_blue_plus plugin.
+version: 1.0.0
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
@@ -16,6 +17,10 @@ dependencies:
     # Note: We use a path dependency because the example app & plugin are bundled together.
     # In *your* app you should use ^1.17.3 or similar 
     path: ../
+
+  cupertino_icons: ^1.0.2
+  permission_handler: ^10.2.0
+  convert: ^3.1.1
 
 flutter:
   uses-material-design: true

--- a/ios/Classes/ErrorCodes.swift
+++ b/ios/Classes/ErrorCodes.swift
@@ -1,0 +1,19 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+class ErrorCodes: NSObject {
+    private override init() {}
+    
+    static let platformNotSupported = "platform_not_supported"
+    static let openL2CapChannelFailed = "open_l2cap_channel_failed"
+    static let closeL2CapChannelFailed = "close_l2cap_channel_failed"
+    static let socketNotOpen = "no_socket_or_stream_is_open"
+    static let inputStreamReadFailed = "input_stream_read_failed"
+    static let outputStreamWriteFailed = "output_stream_write_failed"
+    static let noOpenL2CapChannelFound = "no_open_l2cap_channel_found"
+    static let bluetoothTurnedOff = "bluetooth_turned_off"
+
+}

--- a/ios/Classes/Extensions.swift
+++ b/ios/Classes/Extensions.swift
@@ -1,0 +1,13 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+extension OutputStream {
+  func write(data: Data) -> Int {
+    return data.withUnsafeBytes {
+      write($0.bindMemory(to: UInt8.self).baseAddress!, maxLength: data.count)
+    }
+  }
+}

--- a/ios/Classes/L2CapChannelManager.swift
+++ b/ios/Classes/L2CapChannelManager.swift
@@ -1,0 +1,191 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+import Flutter
+
+@available(iOS 13.0, *)
+@objc
+public class L2CapChannelManager : NSObject, CBPeripheralManagerDelegate {
+
+    private var peripheralManager: CBPeripheralManager?
+    private var openL2CapChannelInfos: [L2CapServerInfo] = []
+    
+    private var listenL2CapChannelCallback: FlutterResult?
+    private var closeL2CapChannelCallback: FlutterResult?
+    
+    private let deviceConnectedMethodChannel: FlutterMethodChannel
+    
+    private var peripheralManagerStateContinuation: CheckedContinuation<CBManagerState, Error>?
+    
+    @objc
+    public init(deviceConnectedMethodChannel: FlutterMethodChannel) {
+        self.deviceConnectedMethodChannel = deviceConnectedMethodChannel
+    }
+    
+    @objc
+    public func listenUsingL2capChannel(request: ListenL2CapChannelRequest, resultCallback: @escaping FlutterResult) {
+        Task {
+            do {
+                let state = try await getPeripheralState()
+                if state != CBManagerState.poweredOn {
+                    resultCallback(FlutterError(code: ErrorCodes.bluetoothTurnedOff, message: "peripheralManager is not in poweredOn state.", details: nil))
+                    return
+                }
+                listenL2CapChannelCallback = resultCallback
+                requirePeripheralManager().publishL2CAPChannel(withEncryption: request.secure)
+            } catch {
+                resultCallback(
+                    FlutterError(
+                        code: ErrorCodes.bluetoothTurnedOff,
+                        message: error.localizedDescription,
+                        details: nil
+                    )
+                )
+            }
+        
+        }
+        
+    }
+    
+    @objc
+    public func connectToL2CapChannel(device: CBPeripheral, request: OpenL2CapChannelRequest, resultCallback: FlutterResult) {
+        let peripheralManager = requirePeripheralManager()
+        if peripheralManager.state != CBManagerState.poweredOn {
+            resultCallback(FlutterError(code: ErrorCodes.bluetoothTurnedOff, message: "peripheralManager is not in poweredOn state.", details: nil))
+            return
+        }
+        LogUtil.log(logLevel: LogLevel.debug, message: "The function connectToL2CapChannel is not implemented yet.")
+    }
+    
+    @objc
+    public func read(request: ReadL2CapChannelRequest, resultCallback: FlutterResult) {
+        let psm = CBL2CAPPSM(request.psm)
+        guard let openChannel = openL2CapChannelInfos.first(where: {$0.getPSM() == psm}) else {
+            LogUtil.log(logLevel: LogLevel.debug, message: String(format: "No open channel found with PSM: %d", psm))
+            resultCallback(FlutterError(code: ErrorCodes.noOpenL2CapChannelFound, message: "No open channel found for device and psm", details: nil))
+            return
+        }
+        guard let deviceUUID = UUID(uuidString: request.remoteId) else {
+            LogUtil.log(logLevel: LogLevel.debug, message: String(format: "Provided device identifier is no UUID: %s", request.remoteId))
+            resultCallback(FlutterError(code: ErrorCodes.inputStreamReadFailed, message: "Provided device identifier is no UUID.", details: nil))
+            return
+        }
+        openChannel.read(deviceIdentifier: deviceUUID, result: resultCallback)
+    }
+    
+    @objc
+    public func write(request: WriteL2CapChannelRequest, resultCallback: FlutterResult) {
+        let psm = CBL2CAPPSM(request.psm)
+        guard let openChannel = openL2CapChannelInfos.first(where: {$0.getPSM() == psm}) else {
+            LogUtil.log(logLevel: LogLevel.debug, message: String(format: "No open channel found with PSM: %d", psm))
+            resultCallback(FlutterError(code: ErrorCodes.noOpenL2CapChannelFound, message: "No open channel found for device and psm", details: nil))
+            return
+        }
+        guard let deviceUUID = UUID(uuidString: request.remoteId) else {
+            LogUtil.log(logLevel: LogLevel.debug, message: String(format: "Provided device identifier is no UUID: %s", request.remoteId))
+            resultCallback(FlutterError(code: ErrorCodes.outputStreamWriteFailed, message: "Provided device identifier is no UUID.", details: nil))
+            return
+        }
+        openChannel.write(deviceIdentifier: deviceUUID, payload: request.value, result: resultCallback)
+    }
+    
+    @objc
+    public func closeChannel(request: CloseL2CapChannelRequest,  resultCallback: @escaping FlutterResult) {
+        let psm = CBL2CAPPSM(request.psm)
+        guard let openChannel = openL2CapChannelInfos.first(where: {$0.getPSM() == psm}) else {
+            LogUtil.log(logLevel: LogLevel.debug, message: String(format: "No open channel found with PSM: %d", psm))
+            resultCallback(FlutterError(code: ErrorCodes.noOpenL2CapChannelFound, message: "No open channel found for device and psm", details: nil))
+            return
+        }
+        guard let deviceUUID = UUID(uuidString: request.remoteId) else {
+            LogUtil.log(logLevel: LogLevel.debug, message: String(format: "Provided device identifier is no UUID: %s", request.remoteId))
+            return
+        }
+        openChannel.close(deviceIdentifier: deviceUUID)
+    }
+    
+    @objc
+    public func closeServerSocket(request: CloseL2CapServer, resultCallback: @escaping FlutterResult) {
+        let peripheralManager = requirePeripheralManager()
+        closeL2CapChannelCallback = resultCallback
+        let psmToClose = CBL2CAPPSM(request.psm)
+        LogUtil.log(logLevel: LogLevel.debug, message: String(format: "Closing L2CapChannel with PSM %d", psmToClose))
+        if let channelToCloseIndex = openL2CapChannelInfos.firstIndex(where: { $0.getPSM() == psmToClose}) {
+            openL2CapChannelInfos[channelToCloseIndex].closeAllConnections()
+            openL2CapChannelInfos.remove(at: channelToCloseIndex)
+        }
+        peripheralManager.unpublishL2CAPChannel(psmToClose)
+    }
+    
+    private func requirePeripheralManager() -> CBPeripheralManager {
+        if peripheralManager == nil {
+            peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
+        }
+        return peripheralManager!
+    }
+    
+    private func getPeripheralState() async throws -> CBManagerState {
+        let peripheralManager = requirePeripheralManager()
+        if peripheralManager.state == .unknown {
+            return try await withCheckedThrowingContinuation { continuation in
+                peripheralManagerStateContinuation = continuation
+            }
+        }
+        return peripheralManager.state
+    }
+ 
+    // MARK: Peripheral Manager Delegates
+    public func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+        LogUtil.log(logLevel: LogLevel.debug, message: "peripheralManagerDidUpdateState called.")
+        peripheralManagerStateContinuation?.resume(returning: peripheral.state)
+        peripheralManagerStateContinuation = nil
+    }
+    
+    public func peripheralManager(_ peripheral: CBPeripheralManager, didPublishL2CAPChannel PSM: CBL2CAPPSM, error: Error?) {
+        if let error = error {
+            NSLog("Published L2Cap channel failed: %s", error.localizedDescription)
+            LogUtil.log(logLevel: LogLevel.error, message: String(format: "Published L2Cap channel failed: %s", error.localizedDescription))
+            guard let listenL2CapChannelCallback = listenL2CapChannelCallback else { return }
+            listenL2CapChannelCallback(error)
+        } else {
+            let response = ListenL2CapChannelResponse(psm: Int(PSM))
+            LogUtil.log(logLevel: LogLevel.debug, message: String(format: "Published L2Cap channel with PSM %d successfully", PSM))
+            openL2CapChannelInfos.append(L2CapServerInfo(psm: PSM))
+            
+            guard let listenL2CapChannelCallback = listenL2CapChannelCallback else { return }
+            listenL2CapChannelCallback(response.marshal())
+        }
+    }
+    
+    public func peripheralManager(_ peripheral: CBPeripheralManager, didUnpublishL2CAPChannel PSM: CBL2CAPPSM, error: Error?) {
+        LogUtil.log(logLevel: LogLevel.debug, message: "ClosedL2Cap channel.")
+        guard let closeL2CapChannelCallback = closeL2CapChannelCallback else { return }
+        closeL2CapChannelCallback(nil)
+    }
+    
+    public func peripheralManager(_ peripheral: CBPeripheralManager, didOpen channel: CBL2CAPChannel?, error: Error?) {
+        LogUtil.log(logLevel: LogLevel.debug, message: "L2Cap Channel opened.")
+        if let error = error {
+            LogUtil.log(logLevel: LogLevel.error, message: String(format: "didOpenL2CapChannel returns error: %s", error.localizedDescription))
+        } else {
+            guard let channel = channel else {
+                LogUtil.log(logLevel: LogLevel.error, message: "No L2Cap channel provided. This should not happen.")
+                return
+            }
+            handleNewConnection(channel: channel)
+        }
+    }
+    
+    private func handleNewConnection(channel : CBL2CAPChannel) {
+        guard let channelInfo = openL2CapChannelInfos.first(where: { $0.getPSM() == channel.psm}) else {
+            return
+        }
+        channelInfo.addConnection(l2CapChannel: channel)
+        
+        let event = DeviceConnectedToL2CapChannel(device: channel.peer, psm: Int(channelInfo.getPSM()))
+        deviceConnectedMethodChannel.invokeMethod(L2CapMethodNames.deviceConnected, arguments: event.marshal())
+    }
+    
+}

--- a/ios/Classes/L2CapMethodNames.swift
+++ b/ios/Classes/L2CapMethodNames.swift
@@ -1,0 +1,18 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+@objc
+public class L2CapMethodNames: NSObject {
+    private override init() {}
+        
+    @objc public static let connectToL2CapChannel = "connectToL2CapChannel"
+    @objc public static let closeL2CapChannel = "closeL2CapChannel"
+    @objc public static let readL2CapChannel = "readL2CapChannel"
+    @objc public static let writeL2CapChannel = "writeL2CapChannel"
+    @objc public static let deviceConnected = "deviceConnectedToL2CapChannel"
+    @objc public static let listenL2CapChannel = "listenL2CapChannel"
+    @objc public static let closeL2CapServer = "closeL2CapServer"
+}

--- a/ios/Classes/L2CapServerInfo.swift
+++ b/ios/Classes/L2CapServerInfo.swift
@@ -1,0 +1,73 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+class L2CapServerInfo {
+    private static let defaultBufferSizeInByte = 50
+    
+    
+    private let psm: CBL2CAPPSM
+    private let readBufferSize: Int
+    private var openChannels: [CBL2CAPChannel] = []
+
+    init(psm: CBL2CAPPSM, readBufferSize: Int = defaultBufferSizeInByte) {
+        self.psm = psm
+        self.readBufferSize = readBufferSize
+    }
+    
+    func getPSM() -> CBL2CAPPSM {
+        return psm
+    }
+    
+    func addConnection(l2CapChannel : CBL2CAPChannel) {
+        openChannels.append(l2CapChannel)
+        l2CapChannel.inputStream.open()
+        l2CapChannel.outputStream.open()
+    }
+    
+    func read(deviceIdentifier: UUID, result: FlutterResult) {
+        guard let channelToRead = openChannels.first(where: { deviceIdentifier == $0.peer.identifier }) else {
+            result(FlutterError(code: ErrorCodes.noOpenL2CapChannelFound, message: "No open channel found for device and psm", details: nil))
+            return
+        }
+        let readBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: readBufferSize)
+        let bytesRead = channelToRead.inputStream.read(readBuffer, maxLength: readBufferSize)
+        
+        let response = ReadL2CapChannelResponse(remoteId: deviceIdentifier.uuidString, psm: Int(psm), bytesRead: bytesRead, value: Data(bytes: readBuffer, count: bytesRead))
+        readBuffer.deallocate()
+        result(response.marshal())
+    }
+    
+    func write(deviceIdentifier: UUID, payload: Data , result: FlutterResult) {
+        guard let channelToWrite = openChannels.first(where: { deviceIdentifier == $0.peer.identifier }) else {
+            result(FlutterError(code: ErrorCodes.noOpenL2CapChannelFound, message: "No open channel found for device and psm", details: nil))
+            return
+        }
+        
+        let bytesWritten = channelToWrite.outputStream.write(data: payload)
+        LogUtil.log(logLevel: LogLevel.debug, message: String(format: "Send %d bytes.", bytesWritten))
+        result(nil)
+    }
+   
+    func close(deviceIdentifier: UUID) {
+        guard let channelToClose = openChannels.firstIndex(where: { deviceIdentifier == $0.peer.identifier }) else {            
+            LogUtil.log(logLevel: LogLevel.error, message: "No open channel found for device and psm")
+            return
+        }
+        openChannels[channelToClose].inputStream.close()
+        openChannels[channelToClose].outputStream.close()
+        
+        openChannels.remove(at: channelToClose)
+    }
+   
+    func closeAllConnections() {
+        openChannels.forEach { channel in
+            channel.inputStream.close()
+            channel.outputStream.close()
+        }
+        openChannels.removeAll()
+    }
+    
+}

--- a/ios/Classes/MessageUtil.swift
+++ b/ios/Classes/MessageUtil.swift
@@ -1,0 +1,49 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+@objc
+public class MessageUtil: NSObject {
+
+    @objc
+    public static func convertHexStringToBytes(hexString: String) -> Data? {
+        if (hexString.count % 2 != 0) {
+            return nil;
+        }
+
+        var data = Data(capacity: hexString.count / 2)
+        let regex = try! NSRegularExpression(pattern: "[0-9a-f]{1,2}", options: .caseInsensitive)
+        regex.enumerateMatches(in: hexString, range: NSRange(hexString.startIndex..., in: hexString)) { match, _, _ in
+            let byteString = (hexString as NSString).substring(with: match!.range)
+            let num = UInt8(byteString, radix: 16)!
+            data.append(num)
+        }
+        
+        guard data.count > 0 else { return nil }
+        return data
+    }
+    
+    @objc
+    public static func convertBytesToHexString(data : Data) -> String {
+        return data
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+    
+    @objc
+    public static func bmBluetoothDevice(peripheral: CBPeer) -> NSDictionary {
+        var deviceName = ""
+        if peripheral is CBPeripheral {
+            deviceName = (peripheral as? CBPeripheral)?.name ?? ""
+        }
+        
+        return [
+            "remote_id":   peripheral.identifier.uuidString,
+            "platform_name":  deviceName,
+        ]
+    }
+    
+    
+}

--- a/ios/Classes/l2capmessages/CloseL2CapChannelRequest.swift
+++ b/ios/Classes/l2capmessages/CloseL2CapChannelRequest.swift
@@ -1,0 +1,22 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+
+import Foundation
+
+@objc
+public class CloseL2CapChannelRequest: NSObject {
+    
+    @objc
+    public let psm: Int
+    @objc
+    public let remoteId: String
+    
+    @objc
+    public init (data: NSDictionary) {
+        self.psm = data[L2CapAttributeNames.keyPsm] as? Int ?? 0
+        self.remoteId = data[L2CapAttributeNames.keyRemoteId] as? String ?? ""
+    }
+                
+}

--- a/ios/Classes/l2capmessages/CloseL2CapServer.swift
+++ b/ios/Classes/l2capmessages/CloseL2CapServer.swift
@@ -1,0 +1,19 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+
+import Foundation
+
+@objc
+public class CloseL2CapServer: NSObject {
+    
+    @objc
+    public let psm: Int
+    
+    @objc
+    public init (data: NSDictionary) {
+        self.psm = data[L2CapAttributeNames.keyPsm] as? Int ?? 0
+    }
+                
+}

--- a/ios/Classes/l2capmessages/DeviceConnectedToL2CapChannel.swift
+++ b/ios/Classes/l2capmessages/DeviceConnectedToL2CapChannel.swift
@@ -1,0 +1,25 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+public class DeviceConnectedToL2CapChannel: NSObject {
+    
+    public let psm: Int
+    public let device: CBPeer
+    
+    public init (device: CBPeer, psm: Int) {
+        self.psm = psm
+        self.device = device
+    }
+                
+    public func marshal() -> NSDictionary {
+        let device = MessageUtil.bmBluetoothDevice(peripheral: device)
+        
+        return [
+            L2CapAttributeNames.keyBluetoothDevice: device,
+            L2CapAttributeNames.keyPsm: psm
+        ]
+    }
+}

--- a/ios/Classes/l2capmessages/L2CapAttributeNames.swift
+++ b/ios/Classes/l2capmessages/L2CapAttributeNames.swift
@@ -1,0 +1,16 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+public class L2CapAttributeNames: NSObject {
+    private override init() {}
+            
+    public static let keyBluetoothDevice = "bluetoothDevice"
+    public static let keyPsm = "psm"
+    public static let keySecure = "secure"
+    public static let keyRemoteId = "remote_id"
+    public static let keyBytesRead = "bytes_read"
+    public static let keyValue = "value"
+}

--- a/ios/Classes/l2capmessages/ListenL2CapChannelRequest.swift
+++ b/ios/Classes/l2capmessages/ListenL2CapChannelRequest.swift
@@ -1,0 +1,19 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+@objc
+public class ListenL2CapChannelRequest: NSObject {
+    
+    @objc
+    public let secure: Bool
+    
+    @objc
+    public init (data: NSDictionary) {
+        let secureValue = data[L2CapAttributeNames.keySecure] as? Bool
+        self.secure = secureValue ?? false
+    }
+                
+}

--- a/ios/Classes/l2capmessages/ListenL2CapChannelResponse.swift
+++ b/ios/Classes/l2capmessages/ListenL2CapChannelResponse.swift
@@ -1,0 +1,18 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+public class ListenL2CapChannelResponse: NSObject {
+    
+    public let psm: Int
+    
+    public init (psm: Int) {
+        self.psm = psm
+    }
+                
+    public func marshal() -> NSDictionary {
+        return [L2CapAttributeNames.keyPsm: psm]
+    }
+}

--- a/ios/Classes/l2capmessages/OpenL2CapChannelRequest.swift
+++ b/ios/Classes/l2capmessages/OpenL2CapChannelRequest.swift
@@ -1,0 +1,24 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+@objc
+public class OpenL2CapChannelRequest: NSObject {
+    
+    @objc
+    public let secure: Bool
+    @objc
+    public let remoteId: String
+    @objc
+    public let psm: Int;
+    
+    @objc
+    public init (data: NSDictionary) {
+        self.secure = data[L2CapAttributeNames.keySecure] as? Bool ?? false
+        self.psm = data[L2CapAttributeNames.keyPsm] as? Int ?? 0
+        self.remoteId = data[L2CapAttributeNames.keyRemoteId] as? String ?? ""
+    }
+                
+}

--- a/ios/Classes/l2capmessages/ReadL2CapChannelRequest.swift
+++ b/ios/Classes/l2capmessages/ReadL2CapChannelRequest.swift
@@ -1,0 +1,22 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+
+import Foundation
+
+@objc
+public class ReadL2CapChannelRequest: NSObject {
+    
+    @objc
+    public let psm: Int
+    @objc
+    public let remoteId: String
+    
+    @objc
+    public init (data: NSDictionary) {
+        self.psm = data[L2CapAttributeNames.keyPsm] as? Int ?? 0
+        self.remoteId = data[L2CapAttributeNames.keyRemoteId] as? String ?? ""
+    }
+                
+}

--- a/ios/Classes/l2capmessages/ReadL2CapChannelResponse.swift
+++ b/ios/Classes/l2capmessages/ReadL2CapChannelResponse.swift
@@ -1,0 +1,30 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+public class ReadL2CapChannelResponse: NSObject {
+    
+    public let psm: Int
+    public let remoteId: String
+    public let bytesRead: Int
+    public let value: Data;
+
+    
+    public init (remoteId: String, psm: Int, bytesRead: Int, value: Data) {
+        self.psm = psm
+        self.remoteId = remoteId
+        self.bytesRead = bytesRead
+        self.value = value
+    }
+                
+    public func marshal() -> NSDictionary {
+        return [
+            L2CapAttributeNames.keyRemoteId: remoteId,
+            L2CapAttributeNames.keyPsm: psm,
+            L2CapAttributeNames.keyBytesRead: bytesRead,
+            L2CapAttributeNames.keyValue: MessageUtil.convertBytesToHexString(data: value)
+        ]
+    }
+}

--- a/ios/Classes/l2capmessages/WriteL2CapChannelRequest.swift
+++ b/ios/Classes/l2capmessages/WriteL2CapChannelRequest.swift
@@ -1,0 +1,25 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+@objc
+public class WriteL2CapChannelRequest: NSObject {
+    
+    @objc
+    public let psm: Int
+    @objc
+    public let remoteId: String
+    @objc
+    public let value: Data
+    
+    @objc
+    public init (data: NSDictionary) {
+        self.psm = data[L2CapAttributeNames.keyPsm] as? Int ?? 0
+        self.remoteId = data[L2CapAttributeNames.keyRemoteId] as? String ?? ""
+        let valueAsString = data[L2CapAttributeNames.keyValue] as? String ?? ""
+        self.value = MessageUtil.convertHexStringToBytes(hexString: valueAsString) ?? Data()
+    }
+                
+}

--- a/ios/Classes/log/LogUtil.swift
+++ b/ios/Classes/log/LogUtil.swift
@@ -1,0 +1,30 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import Foundation
+
+
+@objc
+public enum LogLevel: Int {
+    case none = 0
+    case error = 1
+    case warning = 2
+    case info = 3
+    case debug = 4
+    case verbose = 5
+}
+
+@objc
+public class LogUtil: NSObject {
+    
+    @objc
+    public static var LOG_LEVEL: LogLevel = LogLevel.debug
+    
+    @objc
+    public static func log(logLevel: LogLevel, message: String) {
+        if (logLevel.rawValue <= LOG_LEVEL.rawValue) {            
+            NSLog("[FBP] %@", message)
+        }
+    }
+}

--- a/lib/flutter_blue_plus.dart
+++ b/lib/flutter_blue_plus.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
+import 'package:flutter_blue_plus/src/l2cap_constants.dart';
 
 part 'src/bluetooth_characteristic.dart';
 part 'src/bluetooth_descriptor.dart';
@@ -18,4 +19,5 @@ part 'src/bluetooth_service.dart';
 part 'src/bluetooth_utils.dart';
 part 'src/flutter_blue_plus.dart';
 part 'src/guid.dart';
+part 'src/l2cap_messages.dart';
 part 'src/utils.dart';

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -326,6 +326,7 @@ class BluetoothDevice {
         .newStreamWithInitialValue(initialValue);
   }
 
+
   /// Services Reset Stream
   ///  - uses the GAP Services Changed characteristic (0x2A05)
   ///  - you must re-call discoverServices() when services are reset
@@ -336,6 +337,63 @@ class BluetoothDevice {
         .map((args) => BmBluetoothDevice.fromMap(args))
         .where((p) => p.remoteId == remoteId)
         .map((m) => null);
+  }
+
+  /// Open a L2CAP channel to the Bluetooth Device.
+  Future<void> openL2CapChannel({
+    required final int psm,
+    bool secure = true,
+  }) async {
+    var request = OpenL2CapChannelRequest(
+      remoteId: remoteId.toString(),
+      psm: psm,
+      secure: secure,
+    );
+
+    await FlutterBluePlus._invokeMethod(
+        methodConnectToL2CapChannel, request.toMap());
+  }
+
+  /// Close a L2CAP channel to the Bluetooth Device.
+  Future<void> closeL2CapChannel({required final int psm}) async {
+    var request = CloseL2CapChannelRequest(
+      remoteId: remoteId.toString(),
+      psm: psm,
+    );
+
+    await FlutterBluePlus._invokeMethod(
+        methodCloseL2CapChannel, request.toMap());
+  }
+
+  /// Read from a L2CAP channel
+  Future<List<int>> readL2CapChannel({
+    required final int psm,
+  }) async {
+    final request = ReadL2CapChannelRequest(
+      remoteId: remoteId.toString(),
+      psm: psm,
+    );
+
+    return await FlutterBluePlus._invokeMethod(
+            methodReadL2CapChannel, request.toMap())
+        .then((buffer) => ReadL2CapChannelResponse.fromMap(buffer))
+        .then((readChannelResponse) {
+      return readChannelResponse.value
+          .sublist(0, readChannelResponse.bytesRead);
+    });
+  }
+
+  /// Write some [bytesToSend] using the L2CAP channel with the PSM: [psm]
+  Future<void> writeL2CapChannel(
+      {required final int psm, required final List<int> bytesToSend}) async {
+    var request = WriteL2CapChannelRequest(
+      remoteId: remoteId.toString(),
+      psm: psm,
+      value: bytesToSend,
+    );
+
+    return await FlutterBluePlus._invokeMethod(
+        methodWriteL2CapChannel, request.toMap());
   }
 
   /// Read the RSSI of connected remote device

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -54,6 +54,8 @@ class FlutterBluePlus {
   static LogLevel _logLevel = LogLevel.debug;
   static bool _logColor = true;
 
+  static Stream<L2CapChannelConnected>? _l2CapChannelConnected;
+
   ////////////////////
   //  Public
   //
@@ -177,6 +179,19 @@ class FlutterBluePlus {
       }
     }
     return r.devices.map((d) => BluetoothDevice.fromProto(d)).toList();
+  }
+
+  ///
+  /// Emits a new item every time, when a Device is connecting to an offered
+  /// L2Cap channel.
+  static Stream<L2CapChannelConnected> get l2CapChannelConnected {
+    _l2CapChannelConnected ??= FlutterBluePlus._methodStream.stream
+        .where((m) => m.method == deviceConnectedCallback)
+        .map((m) => m.arguments)
+        .map((sourceMap) {
+      return L2CapChannelConnected.fromMap(sourceMap);
+    });
+    return _l2CapChannelConnected!;
   }
 
   /// Retrieve a list of bonded devices (Android only)
@@ -416,6 +431,26 @@ class FlutterBluePlus {
         await Future.delayed(Duration(milliseconds: 50));
       }
     }
+  }
+
+  /// Opens a Server Socket and returns the PSM, which is needed by
+  /// clients which want to connect to this channel.
+  static Future<int> listenL2CapChannel({
+    bool secure = true,
+  }) async {
+    var request = ListenL2CapChannelRequest(secure: secure);
+
+    return await _invokeMethod(methodListenL2CapChannel, request.toMap())
+        .then((buffer) => ListenL2CapChannelResponse.fromMap(buffer))
+        .then((p) => p.psm);
+  }
+
+  /// Closes the server socket with the provided [psm].
+  /// This closes all open input/output streams to this L2Cap server.
+  static Future<void> closeL2CapServer({required final int psm}) async {
+    var request = CloseL2CapServer(psm: psm);
+
+    return await _invokeMethod(methodCloseL2CapServer, request.toMap());
   }
 
   static Future<dynamic> _methodCallHandler(MethodCall call) async {

--- a/lib/src/l2cap_constants.dart
+++ b/lib/src/l2cap_constants.dart
@@ -1,0 +1,19 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+const methodConnectToL2CapChannel = 'connectToL2CapChannel';
+const methodCloseL2CapChannel = 'closeL2CapChannel';
+const methodReadL2CapChannel = 'readL2CapChannel';
+const methodWriteL2CapChannel = 'writeL2CapChannel';
+const methodListenL2CapChannel = 'listenL2CapChannel';
+const methodCloseL2CapServer = 'closeL2CapServer';
+const deviceConnectedCallback = 'deviceConnectedToL2CapChannel';
+
+const keyBluetoothDevice = 'bluetoothDevice';
+const keyPsm = 'psm';
+const keySecure = 'secure';
+const keyRemoteId = 'remote_id';
+const keyBytesRead = 'bytes_read';
+const keyValue = 'value';
+

--- a/lib/src/l2cap_messages.dart
+++ b/lib/src/l2cap_messages.dart
@@ -1,0 +1,129 @@
+// Copyright 2023, Continental Automotive Technologies GmbH
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+part of flutter_blue_plus;
+
+class L2CapChannelConnected {
+  final BluetoothDevice device;
+  final int psm;
+
+  L2CapChannelConnected.fromMap(Map<dynamic, dynamic> map)
+      : device = BluetoothDevice.fromProto(
+            BmBluetoothDevice.fromMap(map[keyBluetoothDevice])),
+        psm = map[keyPsm];
+}
+
+class ListenL2CapChannelRequest {
+  final bool secure;
+
+  ListenL2CapChannelRequest({required this.secure});
+
+  Map<dynamic, dynamic> toMap() {
+    return {
+      keySecure: secure,
+    };
+  }
+}
+
+class ListenL2CapChannelResponse {
+  final int psm;
+
+  ListenL2CapChannelResponse.fromMap(Map<dynamic, dynamic> map)
+      : psm = map[keyPsm];
+}
+
+class CloseL2CapServer {
+  final int psm;
+
+  CloseL2CapServer({required this.psm});
+
+  Map<dynamic, dynamic> toMap() {
+    return {
+      keyPsm: psm,
+    };
+  }
+}
+
+class OpenL2CapChannelRequest {
+  final String remoteId;
+  final int psm;
+  final bool secure;
+
+  OpenL2CapChannelRequest({
+    required this.remoteId,
+    required this.psm,
+    required this.secure,
+  });
+
+  Map<dynamic, dynamic> toMap() {
+    return {
+      keyPsm: psm,
+      keyRemoteId: remoteId,
+      keySecure: secure,
+    };
+  }
+}
+
+class CloseL2CapChannelRequest {
+  final String remoteId;
+  final int psm;
+
+  CloseL2CapChannelRequest({
+    required this.remoteId,
+    required this.psm,
+  });
+
+  Map<dynamic, dynamic> toMap() {
+    return {
+      keyPsm: psm,
+      keyRemoteId: remoteId,
+    };
+  }
+}
+
+class ReadL2CapChannelRequest {
+  final String remoteId;
+  final int psm;
+
+  ReadL2CapChannelRequest({
+    required this.remoteId,
+    required this.psm,
+  });
+
+  Map<dynamic, dynamic> toMap() {
+    return {
+      keyPsm: psm,
+      keyRemoteId: remoteId,
+    };
+  }
+}
+
+class ReadL2CapChannelResponse {
+  final String remoteId;
+  final int psm;
+  final int bytesRead;
+  final List<int> value;
+
+  ReadL2CapChannelResponse.fromMap(Map<dynamic, dynamic> map)
+      : remoteId = map[keyRemoteId],
+        psm = map[keyPsm],
+        bytesRead = map[keyBytesRead],
+        value = _hexDecode(map[keyValue]);
+}
+
+class WriteL2CapChannelRequest {
+  final String remoteId;
+  final int psm;
+  final List<int> value;
+
+  WriteL2CapChannelRequest(
+      {required this.remoteId, required this.psm, required this.value});
+
+  Map<dynamic, dynamic> toMap() {
+    return {
+      keyPsm: psm,
+      keyRemoteId: remoteId,
+      keyValue: _hexEncode(value),
+    };
+  }
+}


### PR DESCRIPTION
Hello, 

I'd like to add a contribution to your library which we developed in my company Continental Automotive Technologies. Starting with Android 10 / iOS 13 L2Cap channels are supported as additional way of communication using BLE. 

This PR adds:
* Support for opening L2Cap channels for listening (server sockets). (listenL2CapChannel/closeL2CapChannel)
* Enable bidirectional communication between connected devices (writeL2CapChannel/readL2CapChannel on BluetoothDevice class)
* Introduced Logging class which could be used from everywhere in the library. 
* Extraction of some marshalling functions into an own util class `MarshallingUtil`, which allow reuse from different sources. 
* Use Swift for newer code (interoperability is given - I don't have ObjC knowledge).

This is a quite big PR, so I am happy to help bringing this feature in. :)