### PR TITLE
PR: Corrected typo in README example for disconnect reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ var subscription = device.connectionState.listen((BluetoothConnectionState state
         // 1. typically, start a periodic timer that tries to 
         //    reconnect, or just call connect() again right now
         // 2. you must always re-discover services after disconnection!
-        print("${device.disconnectReasonCode} ${device.disconnectReasonDescription}");
+        print("${device.disconnectReason?.code} ${device.disconnectReason?.description}");
     }
 });
 


### PR DESCRIPTION
This pull request fixes a typo in the README file under the example for printing disconnect reasons. The previous code example incorrectly referenced `device.disconnectReasonCode` and `device.disconnectReasonDescription`. The correct properties are accessed via `device.disconnectReason?.code` and `device.disconnectReason?.description`.

Changes
Updated the README file to correct the code example:
