### PR TITLE
Android: enforce 2 second disconnect delay

### DIFF
--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -185,7 +185,15 @@ class BluetoothDevice {
   ///   - [queue] If true, this disconnect request will be executed after all other operations complete.
   ///     If false, this disconnect request will be executed right now, i.e. skipping to the front
   ///     of the fbp operation queue, which is useful to cancel an in-progress connection attempt.
-  Future<void> disconnect({int timeout = 35, bool queue = true}) async {
+  ///   - [androidDelay] Android only. Minimum gap in milliseconds between connect and disconnect to
+  ///     workaround a race condition that leaves connection stranded.
+  ///     https://issuetracker.google.com/issues/37121040
+  ///     From testing, 2 second delay appears to be enough.
+  Future<void> disconnect({
+    int timeout = 35,
+    bool queue = true,
+    int androidDelay = 2000,
+  }) async {
     // Only allow a single disconnect operation at a time
     _Mutex dtx = _MutexFactory.getMutexForKey("disconnect");
     await dtx.take();
@@ -211,7 +219,7 @@ class BluetoothDevice {
       Future<BmConnectionStateResponse> futureState = responseStream.first;
 
       // Workaround Android race condition: ensure minimum connect disconnect gap is met
-      await _ensureMinimumAndroidDelay();
+      await _ensureMinimumAndroidDelay(androidDelay);
 
       // invoke
       bool changed = await FlutterBluePlus._invokeMethod('disconnect', remoteId.str);
@@ -682,10 +690,10 @@ class BluetoothDevice {
   /// Workaround race condition between connect and disconnect leaving connection stranded by enforcing a small delay
   /// between connect and disconnect call.
   /// https://issuetracker.google.com/issues/37121040
-  Future<void> _ensureMinimumAndroidDelay() async {
+  Future<void> _ensureMinimumAndroidDelay(int androidDelay) async {
     if (Platform.isAndroid) {
       if (FlutterBluePlus._connectTimestamp.containsKey(remoteId)) {
-        Duration minGap = Duration(milliseconds: FlutterBluePlus._androidDisconnectMinGapMs);
+        Duration minGap = Duration(milliseconds: androidDelay);
         Duration elapsed = DateTime.now().difference(FlutterBluePlus._connectTimestamp[remoteId]!);
         if (elapsed.compareTo(minGap) < 0) {
           Duration timeLeft = minGap - elapsed;

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -184,7 +184,9 @@ class BluetoothDevice {
   ///     If false, this disconnect request will be executed right now, i.e. skipping to the front
   ///     of the fbp operation queue, which is useful to cancel an in-progress connection attempt.
   ///   - [androidDelay] Android only. Minimum gap in milliseconds between connect and disconnect to
-  ///     workaround a race condition that leaves connection stranded.
+  ///     workaround a race condition that leaves connection stranded. A stranded connection in this case
+  ///     refers to a connection that FBP and Android Bluetooth stack are not aware of and thus cannot be
+  ///     disconnected because there is no gatt handle.
   ///     https://issuetracker.google.com/issues/37121040
   ///     From testing, 2 second delay appears to be enough.
   Future<void> disconnect({

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -219,7 +219,7 @@ class BluetoothDevice {
       Future<BmConnectionStateResponse> futureState = responseStream.first;
 
       // Workaround Android race condition: ensure minimum connect disconnect gap is met
-      await _ensureMinimumAndroidDelay(androidDelay);
+      await _ensureAndroidDisconnectionDelay(androidDelay);
 
       // invoke
       bool changed = await FlutterBluePlus._invokeMethod('disconnect', remoteId.str);
@@ -690,7 +690,7 @@ class BluetoothDevice {
   /// Workaround race condition between connect and disconnect leaving connection stranded by enforcing a small delay
   /// between connect and disconnect call.
   /// https://issuetracker.google.com/issues/37121040
-  Future<void> _ensureMinimumAndroidDelay(int androidDelay) async {
+  Future<void> _ensureAndroidDisconnectionDelay(int androidDelay) async {
     if (Platform.isAndroid) {
       if (FlutterBluePlus._connectTimestamp.containsKey(remoteId)) {
         Duration minGap = Duration(milliseconds: androidDelay);

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -131,10 +131,8 @@ class BluetoothDevice {
       // Start listening now, before invokeMethod, to ensure we don't miss the response
       Future<BmConnectionStateResponse> futureState = responseStream.first;
 
+      // record connection time
       if (Platform.isAndroid) {
-        // Workaround race condition between connect and disconnect leaving connection stranded.
-        // https://issuetracker.google.com/issues/37121040
-        // Record when we initiate connect call so we can enforce a delay between connect and disconnect call.
         FlutterBluePlus._connectTimestamp[remoteId] = DateTime.now();
       }
 

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -109,7 +109,7 @@ class FlutterBluePlus {
   ///       To set this option you must call this method before any other method in this package.
   ///       See: https://developer.apple.com/documentation/corebluetooth/cbcentralmanageroptionshowpoweralertkey
   ///       This option has no effect on Android.
-  ///   - [androidDisconnectMinGapMs] Minimum gap between connect and disconnect calls (Android only).
+  ///   - [androidDisconnectMinGapMs] Minimum gap between connect and disconnect calls in milliseconds (Android only).
   static Future<void> setOptions({
     bool showPowerAlert = true,
     int? androidDisconnectMinGapMs,

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -55,10 +55,6 @@ class FlutterBluePlus {
   static LogLevel _logLevel = LogLevel.debug;
   static bool _logColor = true;
 
-  /// Android: minimum gap between connect and disconnect to workaround a race condition
-  /// From testing, 2 second delay appears to be enough.
-  static int _androidDisconnectMinGapMs = 2000;
-
   ////////////////////
   //  Public
   //
@@ -109,14 +105,9 @@ class FlutterBluePlus {
   ///       To set this option you must call this method before any other method in this package.
   ///       See: https://developer.apple.com/documentation/corebluetooth/cbcentralmanageroptionshowpoweralertkey
   ///       This option has no effect on Android.
-  ///   - [androidDisconnectMinGapMs] Minimum gap between connect and disconnect calls in milliseconds (Android only).
   static Future<void> setOptions({
     bool showPowerAlert = true,
-    int? androidDisconnectMinGapMs,
   }) async {
-    if (androidDisconnectMinGapMs != null) {
-      _androidDisconnectMinGapMs = androidDisconnectMinGapMs;
-    }
     await _invokeMethod('setOptions', {"show_power_alert": showPowerAlert});
   }
 

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -55,6 +55,10 @@ class FlutterBluePlus {
   static LogLevel _logLevel = LogLevel.debug;
   static bool _logColor = true;
 
+  /// Android: minimum gap between connect and disconnect to workaround a race condition
+  /// From testing, 2 second delay appears to be enough.
+  static int _androidDisconnectMinGapMs = 2000;
+
   ////////////////////
   //  Public
   //
@@ -105,9 +109,14 @@ class FlutterBluePlus {
   ///       To set this option you must call this method before any other method in this package.
   ///       See: https://developer.apple.com/documentation/corebluetooth/cbcentralmanageroptionshowpoweralertkey
   ///       This option has no effect on Android.
+  ///   - [androidDisconnectMinGapMs] Minimum gap between connect and disconnect calls (Android only).
   static Future<void> setOptions({
     bool showPowerAlert = true,
+    int? androidDisconnectMinGapMs,
   }) async {
+    if (androidDisconnectMinGapMs != null) {
+      _androidDisconnectMinGapMs = androidDisconnectMinGapMs;
+    }
     await _invokeMethod('setOptions', {"show_power_alert": showPowerAlert});
   }
 

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -29,6 +29,7 @@ class FlutterBluePlus {
   static final Map<DeviceIdentifier, Map<String, List<int>>> _lastDescs = {};
   static final Map<DeviceIdentifier, List<StreamSubscription>> _deviceSubscriptions = {};
   static final Map<DeviceIdentifier, List<StreamSubscription>> _delayedSubscriptions = {};
+  static final Map<DeviceIdentifier, DateTime> _connectTimestamp = {};
   static final List<StreamSubscription> _scanSubscriptions = [];
   static final Set<DeviceIdentifier> _autoConnect = {};
 


### PR DESCRIPTION
Addresses issue #927.
This workaround enforces a 2 second delay between connect and disconnect.
Android bug report: https://issuetracker.google.com/issues/37121040