### PR TITLE
Add support for State Preservation and Restoration (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,13 @@ Add the following to your `Info.plist`
 When this key-value pair is included in the app’s Info.plist file, the system wakes up your app to process ble `read`, `write`, and `subscription` events.
 
 You may also have to use https://pub.dev/packages/workmanager
+To enable use of State Preservation and Restoration, set the `restoreIosState` option to true before starting work:
+```
+FlutterBluePlus.setOptions(restoreIosState: true);
+```
+This will wake up your app even when the app is killed by the OS.
+
+You may also have to use https://pub.dev/packages/flutter_isolate
 
 **Note**: Upon being woken up, an app has around 10 seconds to complete a task. Apps that spend too much time executing in the background can be throttled back by the system or killed.
 

--- a/README.md
+++ b/README.md
@@ -591,13 +591,12 @@ Add the following to your `Info.plist`
 When this key-value pair is included in the app’s Info.plist file, the system wakes up your app to process ble `read`, `write`, and `subscription` events.
 
 You may also have to use https://pub.dev/packages/workmanager
+
 To enable use of State Preservation and Restoration, set the `restoreIosState` option to true before starting work:
 ```
 FlutterBluePlus.setOptions(restoreIosState: true);
 ```
 This will wake up your app even when the app is killed by the OS.
-
-You may also have to use https://pub.dev/packages/flutter_isolate
 
 **Note**: Upon being woken up, an app has around 10 seconds to complete a task. Apps that spend too much time executing in the background can be throttled back by the system or killed.
 

--- a/lib/src/flutter_blue_plus.dart
+++ b/lib/src/flutter_blue_plus.dart
@@ -106,8 +106,10 @@ class FlutterBluePlus {
   ///       This option has no effect on Android.
   static Future<void> setOptions({
     bool showPowerAlert = true,
+    bool restoreIosState = false
   }) async {
-    await _invokeMethod('setOptions', {"show_power_alert": showPowerAlert});
+    await _invokeMethod('setOptions', {"show_power_alert": showPowerAlert,
+      "restore_ios_state": restoreIosState});
   }
 
   /// Turn on Bluetooth (Android only),


### PR DESCRIPTION
This pull request introduces support for State Preservation and Restoration on iOS devices as described in [apple docs](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#:~:text=Adding%20Support%20for%20State%20Preservation%20and%20Restoration). This functionality allows your app to recover its state, including Bluetooth connections, even if the app is terminated by the OS.

Changes:

- Added a new optional argument restoreIosState to the setOptions method of FlutterBluePlus.
- Updated the FlutterBluePlusPlugin.m file to implement state restoration logic for iOS, including reconnect all peripherals on `willRestoreState` callback.
- Updated the README to document the usage of restoreIosState

Please review the implementation details in the provided commits.
We welcome any feedback or suggestions for further improvement.