### PR TITLE
[Android] distinguish read and notification for future completion

### DIFF
--- a/packages/flutter_blue_plus/lib/src/bluetooth_characteristic.dart
+++ b/packages/flutter_blue_plus/lib/src/bluetooth_characteristic.dart
@@ -115,7 +115,8 @@ class BluetoothCharacteristic {
           .where((p) => p.remoteId == request.remoteId)
           .where((p) => p.serviceUuid == request.serviceUuid)
           .where((p) => p.characteristicUuid == request.characteristicUuid)
-          .where((p) => p.primaryServiceUuid == request.primaryServiceUuid);
+          .where((p) => p.primaryServiceUuid == request.primaryServiceUuid)
+          .where((p) => p.receiveEvent != BmReceiveEventEnum.notify);
 
       // Start listening now, before invokeMethod, to ensure we don't miss the response
       Future<BmCharacteristicData> futureResponse = responseStream.first;

--- a/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
+++ b/packages/flutter_blue_plus_android/android/src/main/java/com/lib/flutter_blue_plus/FlutterBluePlusPlugin.java
@@ -2279,7 +2279,7 @@ public class FlutterBluePlusPlugin implements
         }
 
         // called for both notifications & reads
-        public void onCharacteristicReceived(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, byte[] value, int status)
+        public void onCharacteristicReceived(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, byte[] value, int status, int receiveEvent)
         {
             // GATT Service?
             if (uuidStr(characteristic.getService().getUuid()) == "1800") {
@@ -2306,6 +2306,7 @@ public class FlutterBluePlusPlugin implements
             if (primaryService != null) {
                 response.put("primary_service_uuid", uuidStr(primaryService.getUuid()));
             }
+            response.put("receive_event", receiveEvent);
 
             invokeMethodUIThread("OnCharacteristicReceived", response);
         }
@@ -2318,7 +2319,7 @@ public class FlutterBluePlusPlugin implements
             LogLevel level = LogLevel.DEBUG;
             log(level, "onCharacteristicChanged:");
             log(level, "  chr: " + uuidStr(characteristic.getUuid()));
-            onCharacteristicReceived(gatt, characteristic, value, BluetoothGatt.GATT_SUCCESS);
+            onCharacteristicReceived(gatt, characteristic, value, BluetoothGatt.GATT_SUCCESS, 2); // see BmReceiveEventEnum
         }
 
         @Override
@@ -2330,7 +2331,7 @@ public class FlutterBluePlusPlugin implements
             log(level, "onCharacteristicRead:");
             log(level, "  chr: " + uuidStr(characteristic.getUuid()));
             log(level, "  status: " + gattErrorString(status) + " (" + status + ")");
-            onCharacteristicReceived(gatt, characteristic, value, status);
+            onCharacteristicReceived(gatt, characteristic, value, status, 1); // see BmReceiveEventEnum
         }
 
         @Override

--- a/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
+++ b/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
@@ -1441,6 +1441,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         @"success":                     error == nil ? @(1) : @(0),
         @"error_string":                error ? [error localizedDescription] : @"success",
         @"error_code":                  error ? @(error.code) : @(0),
+        @"receive_event":               @(0), // see BmReceiveEventEnum
     } mutableCopy];
 
     // remove if null

--- a/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/src/bluetooth_msgs.dart
@@ -459,6 +459,12 @@ class BmReadCharacteristicRequest {
   }
 }
 
+enum BmReceiveEventEnum {
+  unknown, // 0
+  read, // 1
+  notify, // 2
+}
+
 class BmCharacteristicData {
   final DeviceIdentifier remoteId;
   final Guid serviceUuid;
@@ -468,6 +474,7 @@ class BmCharacteristicData {
   final bool success;
   final int errorCode;
   final String errorString;
+  final BmReceiveEventEnum receiveEvent;
 
 
   BmCharacteristicData({
@@ -479,6 +486,7 @@ class BmCharacteristicData {
     required this.success,
     required this.errorCode,
     required this.errorString,
+    this.receiveEvent = BmReceiveEventEnum.unknown,
   });
 
   factory BmCharacteristicData.fromMap(Map<dynamic, dynamic> json) {
@@ -491,6 +499,7 @@ class BmCharacteristicData {
       success: json['success'] != 0,
       errorCode: json['error_code'],
       errorString: json['error_string'],
+      receiveEvent: BmReceiveEventEnum.values[json['receive_event']],
     );
   }
 }


### PR DESCRIPTION
Hi Chip,

sorry I did not reply to your comments on https://github.com/chipweinberger/flutter_blue_plus/pull/1080.

I have rebased it, rewritten it to use an enumeration and also made "receiveEvent" optional in the constructor of BmCharacteristicData, so that it does not break the Linux and web implementations. I think both of them support this distinction, so if you want me to, I can implement and test it.