### PR TITLE
better Guid equals operator

### DIFF
--- a/packages/flutter_blue_plus_platform_interface/lib/src/guid.dart
+++ b/packages/flutter_blue_plus_platform_interface/lib/src/guid.dart
@@ -84,7 +84,7 @@ class Guid {
   String toString() => str;
 
   @override
-  operator ==(other) => other is Guid && hashCode == other.hashCode;
+  operator ==(other) => other is Guid && str128 == other.str128;
 
   @override
   int get hashCode => str128.hashCode;


### PR DESCRIPTION
A small fix for Guid to improve equals method contract to handle hashcode collisions in maps.