### PR TITLE
fix(darwin): nil-guard rssi in didReadRSSI:error: to prevent crash

### DIFF
--- a/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
+++ b/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
@@ -1724,7 +1724,7 @@ didDiscoverCharacteristicsForService:(CBService *)service
     // See BmReadRssiResult
     NSDictionary* result = @{
         @"remote_id":       [peripheral.identifier UUIDString],
-        @"rssi":            rssi,
+        @"rssi":            rssi ?: @(0),
         @"success":         @(error == nil),
         @"error_string":    error ? [error localizedDescription] : @"success",
         @"error_code":      error ? @(error.code) : @(0),


### PR DESCRIPTION
When CoreBluetooth calls peripheral:didReadRSSI:error: with a non-nil error (e.g. device disconnected mid-read), the rssi parameter can be `nil`. Inserting `nil` into an `NSDictionary` literal causes `NSInvalidArgumentException`, crashing the app.

This is a fatal crash, the app terminates immediately with no recovery path. It occurs when a BLE peripheral disconnects (spontaneously or intentionally) while an RSSI read is in flight.

The fix uses the nil-coalescing operator `(rssi ?: @(0))` to fall back to `0` when `rssi` is `nil`, consistent with how `error_string` and `error_code` are already guarded in the same dictionary.

Crash signature:
```
  NSInvalidArgumentException
  -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]
  -[FlutterBluePlusPlugin peripheral:didReadRSSI:error:]
  FlutterBluePlusPlugin.m:1727
```