### PR TITLE
Unendorse missing WinRT package

### DIFF
--- a/packages/flutter_blue_plus/pubspec.yaml
+++ b/packages/flutter_blue_plus/pubspec.yaml
@@ -55,5 +55,3 @@ flutter:
         default_package: flutter_blue_plus_darwin
       web:
         default_package: flutter_blue_plus_web
-      windows:
-        default_package: flutter_blue_plus_winrt


### PR DESCRIPTION
## Draft status

This PR removes the Windows default-package endorsement for `flutter_blue_plus_winrt` because the package currently does not exist in this repository/package layout and Flutter reports the endorsement as invalid.

This is not an SPM-style metadata workaround and does not claim new platform support. It removes an invalid endorsement so downstream Flutter tooling no longer resolves a missing default implementation.

## Scope

- Removes `windows.default_package: flutter_blue_plus_winrt` from `packages/flutter_blue_plus/pubspec.yaml`.
- Does not change Dart APIs, native code, or runtime behavior for supported platforms.

## Verification

- Consuming app `flutter pub get` no longer reports the missing `flutter_blue_plus_winrt` default package warning when pinned to the fork commit based on the current 2.3.1 dependency.
- `git diff --check`
