### PR TITLE
fix(darwin): reject NSNull in setOptions to prevent crash on Flutter 3.10+

### DIFF
--- a/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
+++ b/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
@@ -112,11 +112,20 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
         if ([@"setOptions" isEqualToString:call.method])
         {
             NSDictionary *args = (NSDictionary*) call.arguments;
-            if (args[@"show_power_alert"] != nil) {
-                self.showPowerAlert = args[@"show_power_alert"];
+            // Flutter 3.10+ MethodChannel codec encodes Dart `null` as
+            // `[NSNull null]`, not `nil`. The old `args[key] != nil` check is
+            // TRUE for NSNull, so NSNull gets stored into the NSNumber* properties
+            // and later `[self.showPowerAlert boolValue]` (during adapter init)
+            // crashes with `-[NSNull boolValue]: unrecognized selector`.
+            // Explicitly reject NSNull so the property stays nil and ObjC's
+            // nil-messaging gives the expected 0 return.
+            id powerAlert = args[@"show_power_alert"];
+            if (powerAlert != nil && ![powerAlert isKindOfClass:[NSNull class]]) {
+                self.showPowerAlert = powerAlert;
             }
-            if (args[@"restore_state"] != nil) {
-                self.restoreState = args[@"restore_state"];
+            id restoreState = args[@"restore_state"];
+            if (restoreState != nil && ![restoreState isKindOfClass:[NSNull class]]) {
+                self.restoreState = restoreState;
             }
             result(@YES);
             return;


### PR DESCRIPTION
Fixes #1333

## Problem

On Flutter 3.10+ / Dart 3.10+, the engine's `StandardMessageCodec` encodes Dart `null` values inside a `Map<String, dynamic>` as `[NSNull null]` instead of being absent from the resulting `NSDictionary`.

`setOptions`'s handler treats `args[@"show_power_alert"] != nil` as a truthy check, but `NSNull != nil` is TRUE — so `[NSNull null]` is stored into `self.showPowerAlert` (typed `NSNumber*`). The crash then materializes on the **first BLE method call** that triggers `CBCentralManager` init, when `[self.showPowerAlert boolValue]` is invoked on the `NSNull` singleton:

```
-[NSNull boolValue]: unrecognized selector sent to instance ...
  5 flutter_blue_plus_darwin -[FlutterBluePlusPlugin handleMethodCall:result:] + 672
```

User-facing symptom is usually `PlatformException` on `getSystemDevices` / `adapterState` / `startScan` — but the actual fault is in `setOptions` stashing `NSNull` into a property earlier.

Android is not affected because Kotlin's safe-cast `as? Boolean` returns `null` for non-Boolean values, including Java `null`.

## Fix

Reject `NSNull` explicitly with `isKindOfClass:[NSNull class]` before assigning. This keeps the property `nil` (its default), and `[nil boolValue]` is a valid ObjC no-op returning 0.

```diff
-    if (args[@"show_power_alert"] != nil) {
-        self.showPowerAlert = args[@"show_power_alert"];
-    }
-    if (args[@"restore_state"] != nil) {
-        self.restoreState = args[@"restore_state"];
-    }
+    id powerAlert = args[@"show_power_alert"];
+    if (powerAlert != nil && ![powerAlert isKindOfClass:[NSNull class]]) {
+        self.showPowerAlert = powerAlert;
+    }
+    id restoreState = args[@"restore_state"];
+    if (restoreState != nil && ![restoreState isKindOfClass:[NSNull class]]) {
+        self.restoreState = restoreState;
+    }
```

## Why minimal patch

* I considered a generic helper (e.g. `safeGet:` that filters `NSNull`), but `setOptions` is the only handler in this file that pulls "typed" values from `args` via `!= nil`. Other handlers cast via `requiredDouble` / `requiredString` etc. which already type-check.
* Same shape as #1186's `FlutterStandardTypedData` fix — codec-shipped non-nil sentinel handled at the use site.

## Verification

* Reverted patch → crash reproducible on Flutter 3.41.2 / iOS 17, 18 with:
  ```dart
  await FlutterBluePlus.setOptions(); // all nulls
  await FlutterBluePlus.systemDevices; // crashes
  ```
* Applied patch → same code path now succeeds; `setOptions(showPowerAlert: true)`, `setOptions(showPowerAlert: false)`, and `setOptions()` (all defaults) all behave correctly.
* No behavior change on Flutter <3.10 (codec there shipped Dart `null` as ObjC `nil`, which the old `!= nil` check already filtered correctly).

## Files changed

* `packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m`
