### PR TITLE
Darwin: only poll for MTU changes during connection

### DIFF
--- a/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
+++ b/packages/flutter_blue_plus_darwin/darwin/flutter_blue_plus_darwin/Sources/flutter_blue_plus_darwin/FlutterBluePlusPlugin.m
@@ -41,6 +41,9 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 @property(nonatomic) NSMutableDictionary *discoveryErrors;
 @property(nonatomic) NSMutableDictionary *didWriteWithoutResponse;
 @property(nonatomic) NSMutableDictionary *peripheralMtu;
+// Consecutive checkForMtuChangesCallback ticks each peripheral's MTU has been unchanged, keyed by
+// peripheral. Used to stop polling once the value has settled.
+@property(nonatomic) NSMutableDictionary *peripheralMtuStableTicks;
 @property(nonatomic) NSMutableDictionary *writeChrs;
 @property(nonatomic) NSMutableDictionary *writeDescs;
 @property(nonatomic) NSMutableDictionary *scanCounts;
@@ -66,6 +69,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     instance.discoveryErrors = [NSMutableDictionary new];
     instance.didWriteWithoutResponse = [NSMutableDictionary new];
     instance.peripheralMtu = [NSMutableDictionary new];
+    instance.peripheralMtuStableTicks = [NSMutableDictionary new];
     instance.writeChrs = [NSMutableDictionary new];
     instance.writeDescs = [NSMutableDictionary new];
     instance.scanCounts = [NSMutableDictionary new];
@@ -142,17 +146,8 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
             self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil options:options];
         }
-        // initialize timer
-        if (self.checkForMtuChangesTimer == nil)
-        {
-            Log(LDEBUG, @"initializing checkForMtuChangesTimer");
-
-            self.checkForMtuChangesTimer = [NSTimer scheduledTimerWithTimeInterval:0.025
-                target:self
-                selector:@selector(checkForMtuChangesCallback) 
-                userInfo:@{}
-                repeats:YES];
-        }
+        // Note: the MTU poll is armed on connect (see didConnectPeripheral), not here. Arming it
+        // here left it running for the process lifetime even with nothing connected.
         // check that we have an adapter, except for the 
         // functions that don't need it
         if (self.centralManager == nil && 
@@ -1090,6 +1085,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     [self.discoveryErrors removeAllObjects];
     [self.didWriteWithoutResponse removeAllObjects];
     [self.peripheralMtu removeAllObjects];
+    [self.peripheralMtuStableTicks removeAllObjects];
     [self.writeChrs removeAllObjects];
     [self.writeDescs removeAllObjects];
 }
@@ -1184,8 +1180,49 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
 // in iOS, mtu is negotatiated once automatically sometime after the
 // the connection process, but there is no platform callback for it.
+// How often to poll for the post-connect MTU settle. The exchange completes in well under a
+// second, so this only has to be fast enough to report it promptly.
+static const NSTimeInterval kMtuPollInterval = 0.1;
+
+// Ticks a peripheral's MTU must be unchanged before it counts as settled (2s at kMtuPollInterval).
+static const int kMtuSettledTicks = 20;
+
+// Start polling for MTU changes, if not already polling.
+//
+// The ATT MTU is negotiated once per connection and is immutable afterwards, so this only needs to
+// run between a connection being established and its MTU settling. It is armed on connect and
+// disarmed by checkForMtuChangesCallback once there is nothing left to observe.
+- (void)armMtuPollIfNeeded
+{
+    if (self.checkForMtuChangesTimer != nil) {
+        return;
+    }
+
+    Log(LDEBUG, @"arming checkForMtuChangesTimer");
+
+    self.checkForMtuChangesTimer = [NSTimer scheduledTimerWithTimeInterval:kMtuPollInterval
+        target:self
+        selector:@selector(checkForMtuChangesCallback)
+        userInfo:@{}
+        repeats:YES];
+}
+
+- (void)disarmMtuPoll
+{
+    if (self.checkForMtuChangesTimer == nil) {
+        return;
+    }
+
+    Log(LDEBUG, @"disarming checkForMtuChangesTimer");
+
+    [self.checkForMtuChangesTimer invalidate];
+    self.checkForMtuChangesTimer = nil;
+}
+
 - (void)checkForMtuChangesCallback
 {
+    bool anyUnsettled = false;
+
     for (NSString *key in self.connectedPeripherals) {
 
         CBPeripheral *peripheral = [self.connectedPeripherals objectForKey:key];
@@ -1200,6 +1237,9 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
             // remember new mtu value
             [self.peripheralMtu setObject:@(curMtu) forKey:peripheral];
 
+            // a change restarts the settle window
+            [self.peripheralMtuStableTicks setObject:@(0) forKey:peripheral];
+
             NSString* remoteId = [[peripheral identifier] UUIDString];
 
             // See BmMtuChangedResponse
@@ -1213,7 +1253,23 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
             // send mtu value
             [self.methodChannel invokeMethod:@"OnMtuChanged" arguments:mtuChanged];
+
+            anyUnsettled = true;
+        } else {
+            NSNumber* ticks = (NSNumber*) [self.peripheralMtuStableTicks objectForKey:peripheral];
+            int nextTicks = (ticks == nil ? 0 : [ticks intValue]) + 1;
+            [self.peripheralMtuStableTicks setObject:@(nextTicks) forKey:peripheral];
+
+            if (nextTicks < kMtuSettledTicks) {
+                anyUnsettled = true;
+            }
         }
+    }
+
+    // Nothing connected, or every connection's MTU has settled: the value cannot change again for
+    // the life of these connections, so stop waking up. A new connection re-arms the poll.
+    if (!anyUnsettled) {
+        [self disarmMtuPoll];
     }
 }
 
@@ -1405,6 +1461,10 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     // remember the connected peripherals of *this app*
     [self.connectedPeripherals setObject:peripheral forKey:remoteId];
 
+    // iOS has no MTU-changed callback and the value is not yet valid here (the ATT exchange
+    // completes asynchronously), so poll until it settles.
+    [self armMtuPollIfNeeded];
+
     // remove from currently connecting peripherals
     [self.currentlyConnectingPeripherals removeObjectForKey:remoteId];
 
@@ -1444,6 +1504,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
     // clear negotiated mtu
     [self.peripheralMtu removeObjectForKey:peripheral];
+    [self.peripheralMtuStableTicks removeObjectForKey:peripheral];
 
     // clear any per-device state that would otherwise leak across reconnects
     [self clearPendingDiscoveryForRemoteId:remoteId];


### PR DESCRIPTION
…change

The MTU poll was armed the first time the plugin touched the central manager and never invalidated, so an app that had used Bluetooth once woke up 40 times a second for the rest of the process lifetime, with nothing connected.

The ATT MTU is negotiated once per connection and is immutable afterwards, so there is only ever a short window worth observing. Arm the timer in didConnectPeripheral instead, and let checkForMtuChangesCallback disarm it once every connected peripheral's MTU has been unchanged for 2s. A new connection re-arms it.

Also drops the poll from 40Hz to 10Hz. The exchange completes well under a second, so the extra 30 wakeups a second bought nothing.

This was causing major resource drain on our phones in practice when the app was connected over BLE in the background.